### PR TITLE
ENH: improve regex for HTMLSpan matching

### DIFF
--- a/mistletoe/html_token.py
+++ b/mistletoe/html_token.py
@@ -45,6 +45,6 @@ class HTMLSpan(span_token.SpanToken):
     Attributes:
         content (str): literal strings rendered as-is.
     """
-    pattern = re.compile(r"<([A-z0-9]+?)(?: .+?)?(:?/>|>.*?<\/\1>))
+    pattern = re.compile(r"<([A-z0-9]+?)(?: .+?)?(:?/>|>.*?<\/\1>)")
     def __init__(self, match_obj):
         self.content = match_obj.group(0)

--- a/mistletoe/html_token.py
+++ b/mistletoe/html_token.py
@@ -45,6 +45,6 @@ class HTMLSpan(span_token.SpanToken):
     Attributes:
         content (str): literal strings rendered as-is.
     """
-    pattern = re.compile(r"<([A-z0-9]+?)(?: .+?)?>.+?<\/\1>")
+    pattern = re.compile(r"<([A-z0-9]+?)(?: .+?)?(:?/>|>.*?<\/\1>))
     def __init__(self, match_obj):
         self.content = match_obj.group(0)


### PR DESCRIPTION
- don't require content in HTMLSpan
- match `<tag ... />` shorthand form instead of just `<tag ... >...</tag>`