### PR TITLE
Initial support for JIRA wiki rendering

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,0 +1,8 @@
+
+INSTALL_DIR=$(HOME)/bin
+
+install: install-md2jira
+
+install-md2jira:
+	cp md2jira.py $(INSTALL_DIR)/md2jira
+	chmod uog+x $(INSTALL_DIR)/md2jira

--- a/contrib/md2jira.py
+++ b/contrib/md2jira.py
@@ -32,9 +32,17 @@ from plugins.jira_renderer import JIRARenderer
 
 usageString = '%s <markdownfile>' % os.path.basename(sys.argv[0])
 helpString = """
+Convert Markdown (CommonMark) to JIRA wiki markup
 -h, --help                        help
 -v, --version                     version
 -o <outfile>, --output=<outfile>  output file, use '-' for stdout (default: stdout)
+"""
+
+"""
+Command-line utility to convert Markdown (CommonMark) to JIRA markup.
+
+JIRA markup spec: https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
+CommonMark spec: http://spec.commonmark.org/0.28/#introduction
 """
 
 class CommandLineParser:

--- a/contrib/md2jira.py
+++ b/contrib/md2jira.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright 2016
+
+import os
+import sys
+import getopt
+import subprocess
+import shutil
+import mistletoe
+from plugins.jira_renderer import JIRARenderer
+
+usageString = '%s <markdownfile>' % os.path.basename(sys.argv[0])
+helpString = """
+-h, --help                        help
+-v, --version                     version
+-o <outfile>, --output=<outfile>  output file, use '-' for stdout (default: stdout)
+"""
+
+class CommandLineParser:
+    def __init__(self):
+        try:
+            optlist, args = getopt.getopt(sys.argv[1:], 'hvo:',
+                                          ['help',
+                                           'version',
+                                           'output='])
+
+        except getopt.GetoptError as err:            
+            sys.stderr.write(err.msg + '\n')
+            sys.stderr.write(usageString + '\n')
+            sys.exit(1)
+
+        app = MarkdownToJIRA()
+        app.run(optlist, args)
+
+
+class MarkdownToJIRA:
+    def __init__(self):
+        self.version = 1.0
+        self.options = {}
+        self.options['output'] = '-'
+        
+    def run(self, optlist, args):
+
+        for o, i in optlist:
+            if o in ('-h', '--help'):
+                sys.stderr.write(usageString + '\n')
+                sys.stderr.write(helpString + '\n')
+                sys.exit(1)
+
+            elif o in ('-v', '--version'):
+                sys.stdout.write('%s\n' % str(self.version))
+                sys.exit(0)
+
+            elif o in ('-o', '--output'):
+                self.options['output'] = i
+                
+        if len(args) < 1:
+            sys.stderr.write(usageString + '\n')
+            sys.exit(1)
+
+
+        with open(args[0], 'r') as infile:
+            rendered = mistletoe.markdown(infile, JIRARenderer)
+
+        if self.options['output'] == '-':
+            sys.stdout.write(rendered)
+        else:
+            with open(self.options['output'], 'w') as outfile:
+                outfile.write(rendered)
+        
+         
+if __name__ == '__main__':
+    CommandLineParser()
+    
+    

--- a/contrib/md2jira.py
+++ b/contrib/md2jira.py
@@ -1,5 +1,26 @@
 #!/usr/bin/env python3
-# Copyright 2016
+# Copyright 2018 Tile, Inc.
+# 
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 
 import os
 import sys

--- a/makefile
+++ b/makefile
@@ -1,14 +1,16 @@
+PYTHON_EXEC=python3
+
 .PHONY: run test coverage integration benchmark
 
 run:
-	python3 -m mistletoe
+	${PYTHON_EXEC} -m mistletoe
 
 test:
-	python3 -m unittest
+	${PYTHON_EXEC} -m unittest
 
 coverage:
 	. venv/bin/activate && \
-	python3 -m coverage run -m unittest && \
+	${PYTHON_EXEC} -m coverage run -m unittest && \
 	coverage report && \
 	deactivate
 
@@ -16,4 +18,4 @@ integration:
 	./test/test_ci.sh 1
 
 benchmark:
-	python3 test/benchmark.py
+	${PYTHON_EXEC} test/benchmark.py

--- a/plugins/jira_renderer.py
+++ b/plugins/jira_renderer.py
@@ -1,0 +1,246 @@
+
+import html
+from itertools import chain
+import mistletoe.html_token as html_token
+import mistletoe.block_token
+from mistletoe.base_renderer import BaseRenderer
+import sys
+
+class JIRARenderer(BaseRenderer):
+    """
+    JIRA renderer class.
+
+    See mistletoe.base_renderer module for more info.
+    """
+    def __init__(self, *extras):
+        """
+        Args:
+            extras (list): allows subclasses to add even more custom tokens.
+        """
+        self.listTokens = []
+        tokens = self._tokens_from_module(html_token)
+        super().__init__(*chain(tokens, extras))
+
+    def render_strong(self, token):
+        template = '*{}*'
+        return template.format(self.render_inner(token))
+
+    def render_emphasis(self, token):
+        template = '_{}_'
+        return template.format(self.render_inner(token))
+
+    def render_inline_code(self, token):
+        template = '{{{{{}}}}}'
+        return template.format(self.render_inner(token))
+
+    def render_strikethrough(self, token):
+        template = '-{}-'
+        return template.format(self.render_inner(token))
+
+    def render_image(self, token):
+        template = '![{inner}]({src})'
+        inner = self.render_inner(token)
+        return template.format(src=token.src, inner=inner)
+
+    def render_footnote_image(self, token):
+        template = '![{inner}]({src})'        
+        maybe_src = self.footnotes.get(token.src.key, '')
+        if maybe_src.find('"') != -1:
+            src = maybe_src[:maybe_src.index(' "')]
+            title = maybe_src[maybe_src.index(' "')+2:-1]
+        else:
+            src = maybe_src
+            title = ''
+        inner = self.render_inner(token)
+        return template.format(src=token.src, inner=inner)
+
+    def render_link(self, token):
+        template = '[{inner}|{target}]'
+        target = escape_url(token.target)
+        inner = self.render_inner(token)
+        return template.format(target=target, inner=inner)
+
+    def render_footnote_link(self, token):
+        template = '[{inner}|{target}]'
+        raw_target = self.footnotes.get(token.target.key, '')
+        target = escape_url(raw_target)
+        inner = self.render_inner(token)
+        return template.format(target=target, inner=inner)
+
+    def render_auto_link(self, token):
+        template = '[{inner}|{target}]'
+        target = escape_url(token.target)
+        inner = self.render_inner(token)
+        return template.format(target=target, inner=inner)
+
+    def render_escape_sequence(self, token):
+        return self.render_inner(token)
+
+    @staticmethod
+    def render_raw_text(token):
+        return html.escape(token.content)
+
+    @staticmethod
+    def render_html_span(token):
+        return token.content
+
+    def render_heading(self, token):
+        template = '\nh{level}. {inner}\n'
+        inner = self.render_inner(token)
+        return template.format(level=token.level, inner=inner)
+
+    def render_quote(self, token):
+        template = 'bq. {inner}\n'
+        return template.format(inner=self.render_inner(token))
+
+    def render_paragraph(self, token):
+        return '{}\n'.format(self.render_inner(token))
+
+    def render_block_code(self, token):
+        # template = '<pre>\n<code{attr}>\n{inner}</code>\n</pre>\n'
+        # if token.language:
+        #     attr = ' class="{}"'.format('lang-{}'.format(token.language))
+        # else:
+        #     attr = ''
+
+        template = '{{code:{attr}}}\n{inner}{{code}}\n'
+        if token.language:
+            attr = '{}'.format(token.language)
+        else:
+            attr = ''
+            
+        inner = self.render_inner(token)
+        return template.format(attr=attr, inner=inner)
+
+    def render_list(self, token):
+        # template = '<{tag}{attr}>\n{inner}</{tag}>\n'
+        # if token.start:
+        #     tag = 'ol'
+        #     attr = ' start="{}"'.format(token.start)
+        # else:
+        #     tag = 'ul'
+        #     attr = ''
+        # inner = self.render_inner(token)
+
+        # if token.start:
+        #     self.tagType = '#'
+            
+        # else:
+        #     self.tagType = '*'
+
+            
+        
+        inner = self.render_inner(token)
+        return inner
+
+    def render_list_item(self, token):
+        
+        template = '{prefix} {inner}\n'
+        #prefix = self.tagType * self.listLevel
+        prefix = ''.join(self.listTokens)
+        result = template.format(prefix=prefix, inner=self.render_inner(token))
+        return result
+        
+        
+    #return '<li>{}</li>\n'.format(self.render_inner(token))
+
+    def render_inner(self, token):
+
+        #print('###{}###'.format(token))
+
+        if isinstance(token, mistletoe.block_token.List):
+            # This needs to be a level
+            #self.listLevel += 1
+            if token.start:
+                self.listTokens.append('#')
+            else:
+                self.listTokens.append('*')
+            
+            #print('###{0} {1}###'.format(token, self.listLevel))
+
+        rendered = [self.render(child) for child in token.children]
+
+        if isinstance(token, mistletoe.block_token.List):
+            #self.listLevel -= 1
+            #print('###EXIT {0} {1}###'.format(token, self.listLevel))
+            del (self.listTokens[-1])
+        
+        
+        return ''.join(rendered)
+        
+
+    def render_table(self, token):
+        # This is actually gross and I wonder if there's a better way to do it.
+        #
+        # The primary difficulty seems to be passing down alignment options to
+        # reach individual cells.
+        template = '{inner}\n'
+        if token.has_header:
+            head_template = '{inner}'
+            #print ('hey', token.children)
+            header = token.children[0]
+            head_inner = self.render_table_row(header, True)
+            head_rendered = head_template.format(inner=head_inner)
+            token._children = token._children[1:]
+            
+        else:
+            head_rendered = ''
+            
+        body_template = '{inner}'
+        body_inner = self.render_inner(token)
+        body_rendered = body_template.format(inner=body_inner)
+        return template.format(inner=head_rendered+body_rendered)
+
+    def render_table_row(self, token, is_header=False):
+        #template = '<tr>\n{inner}</tr>\n'
+        #inner = ''.join([self.render_table_cell(child, is_header)
+        #                 for child in token.children])
+        if is_header:
+            template = '{inner}||\n'
+        else:
+            template = '{inner}|\n'
+            
+        inner = ''.join([self.render_table_cell(child, is_header)
+                         for child in token.children])
+
+        return template.format(inner=inner)
+
+    def render_table_cell(self, token, in_header=False):
+        # template = '<{tag}{attr}>{inner}</{tag}>\n'
+        # tag = 'th' if in_header else 'td'
+        # if token.align is None:
+        #     align = 'left'
+        # elif token.align == 0:
+        #     align = 'center'
+        # elif token.align == 1:
+        #     align = 'right'
+        # attr = ' align="{}"'.format(align)
+
+        if in_header:
+            template = '||{inner}'
+        else:
+            template = '|{inner}'
+        
+        inner = self.render_inner(token)
+        return template.format(inner=inner)
+
+    @staticmethod
+    def render_separator(token):
+        return '----\n'
+
+    @staticmethod
+    def render_html_block(token):
+        return token.content
+
+    def render_document(self, token):
+        self.footnotes.update(token.footnotes)
+        return self.render_inner(token)
+
+def escape_url(raw):
+    """
+    Escape urls to prevent code injection craziness. (Hopefully.)
+    """
+    from urllib.parse import quote
+    return quote(raw, safe='/#:')
+
+    

--- a/plugins/jira_renderer.py
+++ b/plugins/jira_renderer.py
@@ -1,3 +1,25 @@
+# Copyright 2018 Tile, Inc.  All Rights Reserved.
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 
 import html
 from itertools import chain
@@ -38,21 +60,23 @@ class JIRARenderer(BaseRenderer):
         return template.format(self.render_inner(token))
 
     def render_image(self, token):
-        template = '![{inner}]({src})'
+        template = '!{src}!'
         inner = self.render_inner(token)
-        return template.format(src=token.src, inner=inner)
+        return template.format(src=token.src)
 
     def render_footnote_image(self, token):
-        template = '![{inner}]({src})'        
+        template = '!{src}'
         maybe_src = self.footnotes.get(token.src.key, '')
+
+        # sys.stderr.write(maybe_src)
         if maybe_src.find('"') != -1:
             src = maybe_src[:maybe_src.index(' "')]
             title = maybe_src[maybe_src.index(' "')+2:-1]
         else:
             src = maybe_src
             title = ''
-        inner = self.render_inner(token)
-        return template.format(src=token.src, inner=inner)
+
+        return template.format(src=token.src)
 
     def render_link(self, token):
         template = '[{inner}|{target}]'
@@ -68,10 +92,10 @@ class JIRARenderer(BaseRenderer):
         return template.format(target=target, inner=inner)
 
     def render_auto_link(self, token):
-        template = '[{inner}|{target}]'
+        template = '[{target}]'
         target = escape_url(token.target)
-        inner = self.render_inner(token)
-        return template.format(target=target, inner=inner)
+        #inner = self.render_inner(token)
+        return template.format(target=target)
 
     def render_escape_sequence(self, token):
         return self.render_inner(token)

--- a/test/test_plugins/test_jira_renderer.py
+++ b/test/test_plugins/test_jira_renderer.py
@@ -1,0 +1,69 @@
+# Copyright 2018 Tile, Inc.  All Rights Reserved.
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest import TestCase, mock
+from mistletoe.span_token import tokenize_inner
+from plugins.jira_renderer import JIRARenderer
+import random
+import string
+
+class TestJIRARenderer(TestCase):
+    def setUp(self):
+        self.renderer = JIRARenderer()
+        self.renderer.__enter__()
+        self.addCleanup(self.renderer.__exit__, None, None, None)
+
+    # @mock.patch('mistletoe.span_token.RawText')
+    # def test_parse(self, MockRawText):
+    #     tokens = tokenize_inner('text with [[wiki | target]]')
+    #     next(tokens)
+    #     MockRawText.assert_called_with('text with ')
+    #     token = next(tokens)
+    #     self.assertIsInstance(token, GithubWiki)
+    #     self.assertEqual(token.target, 'target')
+    #     next(iter(token.children))
+    #     MockRawText.assert_called_with('wiki')
+
+    def genRandomString(self, n):
+        result = ''.join(random.SystemRandom().choice(string.ascii_letters + string.digits + ' \t') for _ in range(n))
+        return result
+
+    def textFormatTest(self, inputTemplate, outputTemplate):
+        input = self.genRandomString(80)
+        token = next(tokenize_inner(inputTemplate.format(input)))
+        expected = outputTemplate.format(input)
+        actual = self.renderer.render(token)
+        self.assertEqual(expected, actual)
+
+    def test_render_strong(self):
+        self.textFormatTest('**{}**', '*{}*')
+
+    def test_render_emphasis(self):
+        self.textFormatTest('*{}*', '_{}_')
+        
+    def test_render_inline_code(self):
+        self.textFormatTest('`{}`', '{{{{{}}}}}')
+
+    def test_render_strikethrough(self):
+        self.textFormatTest('-{}-', '-{}-')
+
+        

--- a/test/test_plugins/test_jira_renderer.py
+++ b/test/test_plugins/test_jira_renderer.py
@@ -43,12 +43,16 @@ class TestJIRARenderer(TestCase):
     #     next(iter(token.children))
     #     MockRawText.assert_called_with('wiki')
 
-    def genRandomString(self, n):
-        result = ''.join(random.SystemRandom().choice(string.ascii_letters + string.digits + ' \t') for _ in range(n))
+    def genRandomString(self, n, hasWhitespace=False):
+        source = string.ascii_letters + string.digits
+        if hasWhitespace:
+            source = source + ' \t'
+        
+        result = ''.join(random.SystemRandom().choice(source) for _ in range(n))
         return result
 
     def textFormatTest(self, inputTemplate, outputTemplate):
-        input = self.genRandomString(80)
+        input = self.genRandomString(80, True)
         token = next(tokenize_inner(inputTemplate.format(input)))
         expected = outputTemplate.format(input)
         actual = self.renderer.render(token)
@@ -66,4 +70,84 @@ class TestJIRARenderer(TestCase):
     def test_render_strikethrough(self):
         self.textFormatTest('-{}-', '-{}-')
 
+    def test_render_image(self):
+        token = next(tokenize_inner('![image](foo.jpg)'))
+        expected = '!foo.jpg!'
+        actual = self.renderer.render(token)
+        self.assertEqual(expected, actual)
+    
+    def test_render_footnote_image(self):
+        # token = next(tokenize_inner('![image]\n\n[image]: foo.jpg'))
+        # expected = '!foo.jpg!'
+        # actual = self.renderer.render(token)
+        # self.assertEqual(expected, actual)
+        pass
+
+    def test_render_link(self):
+        url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
+        body = self.genRandomString(80, True)
+        token = next(tokenize_inner('[{body}]({url})'.format(url=url, body=body)))
+        expected = '[{body}|{url}]'.format(url=url, body=body)
+        actual = self.renderer.render(token)
+        self.assertEqual(expected, actual)
+    
+    def test_render_footnote_link(self):
+        pass
+
+    def test_render_auto_link(self):
+        url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
+        token = next(tokenize_inner('<{url}>'.format(url=url)))
+        expected = '[{url}]'.format(url=url)
+        actual = self.renderer.render(token)
+        self.assertEqual(expected, actual)
         
+    def test_render_escape_sequence(self):
+        pass
+
+    def test_render_html_span(self):
+        pass
+
+    def test_render_heading(self):
+        pass
+        
+    def test_render_quote(self):
+        pass
+
+    def test_render_paragraph(self):
+        pass
+
+    def test_render_block_code(self):
+        pass
+
+    def test_render_list(self):
+        pass
+
+    def test_render_list_item(self):
+        pass
+
+    def test_render_inner(self):
+        pass
+
+    def test_render_table(self):
+        pass
+
+    def test_render_table_row(self):
+        pass
+
+    def test_render_table_cell(self):
+        pass
+
+    def test_render_separator(self):
+        pass
+
+    def test_render_html_block(self):
+        pass
+
+    def test_render_document(self):
+        pass
+    
+    
+
+
+    
+    


### PR DESCRIPTION
This PR includes support for rendering JIRA wiki markup as specified in <https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all>

An additional script `md2jira.py` will convert a Markdown (CommonMark) formatted file to JIRA wiki and can be installed in the `bin` directory of the user's home.