### PR TITLE
Fix for tiny import bug

### DIFF
--- a/contrib/md2jira.py
+++ b/contrib/md2jira.py
@@ -28,7 +28,7 @@ import getopt
 import subprocess
 import shutil
 import mistletoe
-from plugins.jira_renderer import JIRARenderer
+from jira_renderer import JIRARenderer
 
 usageString = '%s <markdownfile>' % os.path.basename(sys.argv[0])
 helpString = """


### PR DESCRIPTION
This fixes the import because currently, `jira_renderer.py` is in `/contrib` and there is no `/plugins` directory.
