### PR TITLE
Headline fix

### DIFF
--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -109,7 +109,7 @@ class JIRARenderer(BaseRenderer):
         return token.content
 
     def render_heading(self, token):
-        template = '\nh{level}. {inner}\n'
+        template = 'h{level}. {inner}\n'
         inner = self.render_inner(token)
         return template.format(level=token.level, inner=inner)
 


### PR DESCRIPTION
The newline at this point is unnecessary and for example, it creates a line break at the beginning of each document that begins with a headline. 