### PR TITLE
Backtrack a minimum of one character when footnote does not match

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -851,7 +851,7 @@ class Footnote(BlockToken):
 
     @staticmethod
     def backtrack(lines, string, offset):
-        lines._index -= string[offset+1:].count('\n')
+        lines._index -= max(1, string[offset+1:].count('\n'))
 
 
 class ThematicBreak(BlockToken):

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -308,6 +308,11 @@ class TestDocument(unittest.TestCase):
         self.assertIsInstance(document.children[0], block_token.Paragraph)
         self.assertEqual(len(document.children), 1)
 
+    def test_missing_final_newline(self):
+        lines = "[link](example.com)"
+        document = block_token.Document(lines)
+        self.assertIsInstance(document.children[0], block_token.Paragraph)
+
 
 class TestThematicBreak(unittest.TestCase):
     def test_match(self):


### PR DESCRIPTION
When a footnote fails to match in Footnote.match_reference, `lines._index` is moved backwards by a number of characters equal to the number of newlines remaining in `lines`. This causes buggy behavior when the input markdown does not contain any newlines, because `lines._index` does not change.

Instead, always backtrack at least one character, so the token start `[` is covered in case there are zero newlines.

---

I confess I do not fully understand the Footnote parsing. It may seem that the correct behavior is actually to always backtrack one character?
```python
def backtrack(lines, string, offset):
    lines._index -= 1
```
The tests pass for either solution.