### PR TITLE
Allow more than one level of token subclass

### DIFF
--- a/mistletoe/base_renderer.py
+++ b/mistletoe/base_renderer.py
@@ -4,7 +4,6 @@ Base class for renderers.
 
 import re
 import sys
-import inspect
 from mistletoe import block_token, span_token
 
 class BaseRenderer(object):
@@ -73,7 +72,11 @@ class BaseRenderer(object):
         self._extras = extras
 
         for token in extras:
-            inspect.getmodule(token.__bases__[0]).add_token(token)
+            if issubclass(token, span_token.SpanToken):
+                token_module = span_token
+            else:
+                token_module = block_token
+            token_module.add_token(token)
             render_func = getattr(self, self._cls_to_func(token.__name__))
             self.render_map[token.__name__] = render_func
 


### PR DESCRIPTION
Currently you subclass a token and then subclass that token…

For example:

```python
class Foo(SpanToken):

    pass


class Bar(Foo):

    pattern = re.compile('(@@@)')


class BarRenderer(HTMLRenderer):

    def __init__(self):
        super().__init__(Bar)


mistletoe.markdown('', BarRenderer)
```

gives the following error:
```
Traceback (most recent call last):
  File "bug.py", line 21, in <module>
    mistletoe.markdown('', BarRenderer)
  File "/path/to/mistletoe/lib/python3.7/site-packages/mistletoe/__init__.py", line 18, in markdown
    with renderer() as renderer:
  File "bug.py", line 18, in __init__
    super().__init__(Bar)
  File "/path/to/mistletoe/lib/python3.7/site-packages/mistletoe/html_renderer.py", line 30, in __init__
    super().__init__(*chain((HTMLBlock, HTMLSpan), extras))
  File "/path/to/mistletoe/lib/python3.7/site-packages/mistletoe/base_renderer.py", line 76, in __init__
    inspect.getmodule(token.__bases__[0]).add_token(token)
AttributeError: module '__main__' has no attribute 'add_token'

```

This PR offers to detect if a token is span or block based on subclass of the `SpanToken` instance instead of using the `inspect` module.