### PR TITLE
Include `span` and `svg` in the span token tags

### DIFF
--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -223,8 +223,8 @@ _tags = {'address', 'article', 'aside', 'base', 'basefont', 'blockquote',
         'footer', 'form', 'frame', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5',
         'h6', 'head', 'header', 'hr', 'html', 'iframe', 'legend', 'li', 'link',
         'main', 'menu', 'menuitem', 'meta', 'nav', 'noframes', 'ol',
-        'optgroup', 'option', 'p', 'param', 'section', 'source', 'summary',
-        'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'title', 'tr', 'track',
+        'optgroup', 'option', 'p', 'param', 'section', 'span', 'source', 'summary',
+        'svg', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'title', 'tr', 'track',
         'ul'}
 
 _tag   = r'[A-Za-z][A-Za-z0-9-]*'


### PR DESCRIPTION
I thought these would be useful tags to add the span token tags set for discovering inline html. 