### PR TITLE
Add `traverse` function, to recursively yield children of a token

### DIFF
--- a/mistletoe/utils.py
+++ b/mistletoe/utils.py
@@ -1,0 +1,32 @@
+from collections import namedtuple
+
+TraverseResult = namedtuple('TraverseResult', ['node', 'parent', 'depth'])
+
+
+def traverse(source, klass=None, depth=None, include_source=False):
+    """Traverse the syntax tree, recursively yielding children.
+
+    Args:
+
+        source: The source syntax token
+        klass: filter children by a certain token class
+        depth (int): The depth to recurse into the tree
+        include_source (bool): whether to first yield the source element
+
+    Yields:
+        A container for an element, its parent and depth
+    """
+    current_depth = 0
+    if include_source:
+        yield TraverseResult(source, None, current_depth)
+    next_children = [(source, c) for c in getattr(source, 'children', [])]
+    while next_children and (depth is None or current_depth > depth):
+        current_depth += 1
+        new_children = []
+        for parent, child in next_children:
+            if klass is None or issubclass(child, klass):
+                yield TraverseResult(child, parent, current_depth)
+            new_children.extend(
+                [(child, c) for c in getattr(child, 'children', [])]
+            )
+        next_children = new_children

--- a/test/test_traverse.py
+++ b/test/test_traverse.py
@@ -1,0 +1,36 @@
+from textwrap import dedent
+import unittest
+
+from mistletoe import Document
+from mistletoe.utils import traverse
+
+
+class TestTraverse(unittest.TestCase):
+    def test_a(self):
+        doc = Document(
+            dedent(
+                """\
+            a **b**
+
+            c [*d*](link)
+            """
+            )
+        )
+        tree = [
+            (t.node.__class__.__name__, t.parent.__class__.__name__, t.depth)
+            for t in traverse(doc)
+        ]
+        self.assertEqual(
+            tree,
+            [
+                ('Paragraph', 'Document', 1),
+                ('Paragraph', 'Document', 1),
+                ('RawText', 'Paragraph', 2),
+                ('Strong', 'Paragraph', 2),
+                ('RawText', 'Paragraph', 2),
+                ('Link', 'Paragraph', 2),
+                ('RawText', 'Strong', 3),
+                ('Emphasis', 'Link', 3),
+                ('RawText', 'Emphasis', 4),
+            ]
+        )


### PR DESCRIPTION
This PR introduces a simple `traverse` function for 'walking through the syntax tree.