### PR TITLE
JIRARenderer: fix list items to have a single newline in between each instead of two

### DIFF
--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -118,7 +118,7 @@ class JIRARenderer(BaseRenderer):
         return inner
 
     def render_list_item(self, token):
-        template = '{prefix} {inner}\n'
+        template = '{prefix} {inner}'
         prefix = ''.join(self.listTokens)
         result = template.format(prefix=prefix, inner=self.render_inner(token))
         return result


### PR DESCRIPTION
this change is important especially for numbered lists, because with 2 lines between items in numbered lists, jira interprets that as each item being a separate list, and restarts numbering from 1.

Tested
```
    $ python3
    >>> from mistletoe.contrib.jira_renderer import JIRARenderer
    >>> import mistletoe
    >>> mistletoe.markdown('1. step one\n2. step two\n3. step three\n', JIRARenderer)
    '# step one\n# step two\n# step three\n'
    >>> mistletoe.markdown('1. step one\n2. step two\n    - blah\n    - blah\n3. step three\n', JIRARenderer)
    '# step one\n# step two\n#* blah\n#* blah\n# step three\n'
    >>> mistletoe.markdown('1. step one\n2. step two\n    1. blah\n    2. blah\n3. step three\n', JIRARenderer)
    '# step one\n# step two\n## blah\n## blah\n# step three\n'
```