### PR TITLE
JIRARenderer: Fix empty lines between block elements and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 build/
 .DS_Store
 *.vim
+.vscode/

--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -79,7 +79,7 @@ class JIRARenderer(BaseRenderer):
 
     @staticmethod
     def render_raw_text(token):
-        return html.escape(token.content)
+        return token.content
 
     @staticmethod
     def render_html_span(token):

--- a/mistletoe/cli.py
+++ b/mistletoe/cli.py
@@ -24,9 +24,9 @@ def convert_file(filename, renderer):
     Parse a Markdown file and dump the output to stdout.
     """
     try:
-        with open(filename, 'r') as fin:
+        with open(filename, 'r', encoding='utf-8') as fin:
             rendered = mistletoe.markdown(fin, renderer)
-            print(rendered, end='')
+            sys.stdout.buffer.write(rendered.encode())
     except OSError:
         sys.exit('Cannot open file "{}".'.format(filename))
 

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -1,0 +1,38 @@
+"""
+Base classes for tests.
+"""
+
+from unittest import TestCase
+from mistletoe.block_token import Document
+
+class BaseRendererTest(TestCase):
+    """
+    Base class for tests of renderers.
+    """
+    def filesBasedTest(func):
+        """
+        Note: Use this as a decorator on a test function with an empty body.
+        This is a realization of the "convention over configuration"
+        practice. You only need to define a unique ``sampleOutputExtension`` within your
+        test case setup, in addition to the ``renderer`` under the test of course.
+
+        Runs the current renderer against input parsed from a file and
+        asserts that the renderer output is equal to content stored in another file.
+        Both the "input" and "expected output" files need to have the same ``filename``
+        that is extracted from the decorated test function name.
+        """
+        def wrapper(self):
+            # take the string after the last '__' in function name
+            filename = func.__name__
+            filename = filename.split('__', 1)[1]
+
+            # parse input markdown, call render on it and check the output
+            with open('test/samples/{}.md'.format(filename), 'r') as fin:
+                actual = self.renderer.render(Document(fin))
+
+                with open('test/samples/{}.{}'.format(filename, self.sampleOutputExtension), 'r') as expectedFin:
+                    expected = ''.join(expectedFin)
+
+                self.assertEqual(expected, actual)
+        return wrapper
+    

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -9,6 +9,9 @@ class BaseRendererTest(TestCase):
     """
     Base class for tests of renderers.
     """
+    def setUp(self):
+        self.maxDiff = None
+
     def filesBasedTest(func):
         """
         Note: Use this as a decorator on a test function with an empty body.

--- a/test/samples/basic_blocks.jira
+++ b/test/samples/basic_blocks.jira
@@ -1,0 +1,26 @@
+h1. Line endings are important not only in Markdown...
+
+h2. Soft break
+
+Line continues - this is "soft break".
+
+h2. Hard break
+
+Line.\\
+Another Line because the previous ends with at least two spaces.
+
+Line.\\
+Another line because the previous ends with a "\".
+
+h2. Other block elements
+
+||A1||B1||C1||
+|A1|B1|C1|
+|A2|B2|C2|
+|A3|B3|C3|
+
+A paragraph under a table.
+
+----
+A paragraph under a horizontal line.
+

--- a/test/samples/basic_blocks.jira
+++ b/test/samples/basic_blocks.jira
@@ -24,3 +24,24 @@ A paragraph under a table.
 ----
 A paragraph under a horizontal line.
 
+h2. Code blocks
+
+Java code:
+
+{code:java}
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}
+{code}
+
+Log file:
+
+{code}
+2020-07-05 10:20:55 ...
+2020-07-05 10:20:56 ...
+    ...
+2020-07-05 10:21:03 ...
+{code}
+

--- a/test/samples/basic_blocks.md
+++ b/test/samples/basic_blocks.md
@@ -1,0 +1,27 @@
+# Line endings are important not only in Markdown...
+
+## Soft break
+
+Line
+continues - this is "soft break".
+
+## Hard break
+
+Line.  
+Another Line because the previous ends with at least two spaces.
+
+Line.\
+Another line because the previous ends with a "\\".
+
+## Other block elements
+
+Column A | Column B | Column C
+---------|----------|---------
+ A1 | B1 | C1
+ A2 | B2 | C2
+ A3 | B3 | C3
+
+A paragraph under a table.
+
+----
+A paragraph under a horizontal line.

--- a/test/samples/basic_blocks.md
+++ b/test/samples/basic_blocks.md
@@ -25,3 +25,22 @@ A paragraph under a table.
 
 ----
 A paragraph under a horizontal line.
+
+## Code blocks
+
+Java code:
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}
+```
+
+Log file:
+
+    2020-07-05 10:20:55 ...
+    2020-07-05 10:20:56 ...
+        ...
+    2020-07-05 10:21:03 ...

--- a/test/samples/lists.jira
+++ b/test/samples/lists.jira
@@ -1,0 +1,29 @@
+h2. Basic list
+
+* fruit
+** apple
+** orange
+*** Note: Orange is also a color.
+** lemon
+
+h2. Spaced list
+
+* vegetable
+** carrot
+** cucumber
+
+h2. Combined list
+
+# firstly
+# secondly
+#* s-first
+another paragraph in s-first
+bq. line quote in s-first
+#* s-second
+{code}
+with some code block in s-second
+{code}
+# thirdly
+
+Another paragraph.
+

--- a/test/samples/lists.md
+++ b/test/samples/lists.md
@@ -1,0 +1,33 @@
+## Basic list
+
+* fruit
+    * apple
+    * orange
+      * Note: Orange is also a color.
+    * lemon
+
+## Spaced list
+
+* vegetable
+
+    * carrot
+
+    * cucumber
+
+## Combined list
+
+1. firstly
+2. secondly
+    * s-first
+
+      another paragraph in s-first
+
+      > line quote in s-first
+      
+    * s-second
+      ```
+      with some code block in s-second
+      ```
+3. thirdly
+
+Another paragraph.

--- a/test/samples/quotes.jira
+++ b/test/samples/quotes.jira
@@ -1,0 +1,35 @@
+h2. Quotes
+
+bq. A single quote
+
+A response to single quote.
+
+{quote}
+A quote spreading...
+
+... multiple paragraphs
+{quote}
+
+Quote with a list inside:
+
+{quote}
+# first
+# second
+{quote}
+
+Nested quotes:
+
+{quote}
+bq. Nested line quote
+
+Quoted paragraph.
+
+{quote}
+Nested block quote.
+
+Jira does not seem to support this though - maybe we cannot do anything about it?
+{quote}
+{quote}
+
+Another paragraph.
+

--- a/test/samples/quotes.md
+++ b/test/samples/quotes.md
@@ -1,0 +1,26 @@
+## Quotes
+
+> A single quote
+
+A response to single quote.
+
+> A quote spreading...
+> 
+> ... multiple paragraphs
+
+Quote with a list inside:
+
+> 1. first
+> 2. second
+
+Nested quotes:
+
+>> Nested line quote
+>
+> Quoted paragraph.
+>
+>> Nested block quote.
+>> 
+>> Jira does not seem to support this though - maybe we cannot do anything about it?
+
+Another paragraph.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -36,20 +36,20 @@ class TestCLI(TestCase):
         mock_convert_file.assert_has_calls(calls)
 
     @patch('mistletoe.markdown', return_value='rendered text')
-    @patch('builtins.print')
+    @patch('sys.stdout.buffer.write')
     @patch('builtins.open', new_callable=mock_open)
-    def test_convert_file_success(self, mock_open_, mock_print, mock_markdown):
+    def test_convert_file_success(self, mock_open_, mock_write, mock_markdown):
         filename = 'foo'
         cli.convert_file(filename, sentinel.RendererCls)
-        mock_open_.assert_called_with(filename, 'r')
-        mock_print.assert_called_with('rendered text', end='')
+        mock_open_.assert_called_with(filename, 'r', encoding='utf-8')
+        mock_write.assert_called_with('rendered text'.encode())
 
     @patch('builtins.open', side_effect=OSError)
     @patch('sys.exit')
     def test_convert_file_fail(self, mock_exit, mock_open_):
         filename = 'foo'
         cli.convert_file(filename, sentinel.RendererCls)
-        mock_open_.assert_called_with(filename, 'r')
+        mock_open_.assert_called_with(filename, 'r', encoding='utf-8')
         mock_exit.assert_called_with('Cannot open file "foo".')
 
     @patch('mistletoe.cli._import_readline')

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -33,6 +33,7 @@ filesBasedTest = BaseRendererTest.filesBasedTest
 class TestJIRARenderer(BaseRendererTest):
 
     def setUp(self):
+        super().setUp()
         self.renderer = JIRARenderer()
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -21,16 +21,22 @@
 # SOFTWARE.
 
 from unittest import TestCase, mock
+from test.base_test import BaseRendererTest
+from mistletoe.block_token import Document
 from mistletoe.span_token import tokenize_inner
 from contrib.jira_renderer import JIRARenderer
 import random
 import string
 
-class TestJIRARenderer(TestCase):
+filesBasedTest = BaseRendererTest.filesBasedTest
+
+class TestJIRARenderer(BaseRendererTest):
+
     def setUp(self):
         self.renderer = JIRARenderer()
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)
+        self.sampleOutputExtension = 'jira'
 
     def genRandomString(self, n, hasWhitespace=False):
         source = string.ascii_letters + string.digits
@@ -134,9 +140,15 @@ class TestJIRARenderer(TestCase):
 
     def test_render_document(self):
         pass
-    
-    
 
+    @filesBasedTest
+    def test_render__basic_blocks(self):
+        pass
 
-    
-    
+    @filesBasedTest
+    def test_render__lists(self):
+        pass
+
+    @filesBasedTest
+    def test_render__quotes(self):
+        pass


### PR DESCRIPTION
Like #97, this mainly **removes empty lines within lists** for their proper Jira rendering.

It also **fixes other JIRARenderer problems**, so that the renderer is basically usable for real-world scenarios. In short, the main fixes (see individual commits for more details):

* Properly separate paragraphs and others by an empty line.
* Line as well as block quotes are generated.
* Don't HTML-escape all the text. (or please explain why to do it)
* The intended outputs are covered by unit tests which can be easily extended by following a simple naming convention.

Note that I'm rather a Python newbie, so don't hesitate to correct me to possibly better follow the Python-style coding.