### PR TITLE
Fix jira_renderer to correctly output table headers; add a test.

### DIFF
--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -147,7 +147,7 @@ class JIRARenderer(BaseRenderer):
         template = '{inner}\n'
         if hasattr(token, 'header'):
             head_template = '{inner}'
-            header = token.children[0]
+            header = token.header
             head_inner = self.render_table_row(header, True)
             head_rendered = head_template.format(inner=head_inner)
              

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -22,6 +22,7 @@
 
 from unittest import TestCase, mock
 from mistletoe.span_token import tokenize_inner
+from mistletoe import Document
 from contrib.jira_renderer import JIRARenderer
 import random
 import string
@@ -135,8 +136,14 @@ class TestJIRARenderer(TestCase):
     def test_render_document(self):
         pass
     
-    
+    def test_table_header(self):
+        markdown = """\
+| header row   |
+|--------------|
+| first cell   |
+"""
 
-
-    
-    
+        expected = "||header row||\n|first cell|\n\n"
+        with JIRARenderer() as renderer:
+            output = renderer.render(Document(markdown))
+            self.assertEqual(output, expected)


### PR DESCRIPTION
A small fix; without it the first (header) row was replaced with the second row.