### PR TITLE
Update jira_renderer.py - Fix rendering of empty table cells

### DIFF
--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -177,6 +177,8 @@ class JIRARenderer(BaseRenderer):
             template = '|{inner}'
         
         inner = self.render_inner(token)
+        if inner == '':
+            inner = ' '
         return template.format(inner=inner)
 
     @staticmethod


### PR DESCRIPTION
```
|    Table    | Non_unique |  Key_name | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Visible | Expression |
|-------------|------------|-----------|--------------|-------------|-----------|-------------|----------|--------|------|------------|---------|---------------|---------|------------|
| page_config |     0      |  PRIMARY  |      1       |      id     |     A     |      27     |   None   |  None  |      |   BTREE    |         |               |   YES   |    None    |
| page_config |     0      | UNIQ_USER |      1       |   user_id   |     A     |      27     |   None   |  None  |      |   BTREE    |         |               |   YES   |    None    |
```
after jira_render, got
```
||Table||Non_unique||Key_name||Seq_in_index||Column_name||Collation||Cardinality||Sub_part||Packed||Null||Index_type||Comment||Index_comment||Visible||Expression||
|page_config|0|PRIMARY|1|id|A|27|None|None||BTREE|||YES|None|
|page_config|0|UNIQ_USER|1|user_id|A|27|None|None||BTREE|||YES|None|
```

![image](https://user-images.githubusercontent.com/24428128/131987831-eb701068-fffd-4ff9-8c5f-46b59789c201.png)