### PR TITLE
Add __repr__ methods to all token classes

### DIFF
--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -5,7 +5,7 @@ Built-in span-level token classes.
 import html
 import re
 import mistletoe.span_tokenizer as tokenizer
-from mistletoe import core_tokens
+from mistletoe import core_tokens, token
 
 
 """
@@ -64,7 +64,7 @@ def reset_tokens():
     _token_types = [globals()[cls_name] for cls_name in __all__]
 
 
-class SpanToken:
+class SpanToken(token.Token):
     parse_inner = True
     parse_group = 1
     precedence = 5
@@ -139,6 +139,7 @@ class Image(SpanToken):
         src (str): image source.
         title (str): image title (default to empty).
     """
+    repr_attributes = ("src", "title")
     def __init__(self, match):
         self.src = EscapeSequence.strip(match.group(2).strip())
         self.title = EscapeSequence.strip(match.group(3))
@@ -151,6 +152,7 @@ class Link(SpanToken):
     Attributes:
         target (str): link target.
     """
+    repr_attributes = ("target", "title")
     def __init__(self, match):
         self.target = EscapeSequence.strip(match.group(2).strip())
         self.title = EscapeSequence.strip(match.group(3))
@@ -164,6 +166,7 @@ class AutoLink(SpanToken):
         children (iterator): a single RawText node for alternative text.
         target (str): link target.
     """
+    repr_attributes = ("target", "mailto")
     pattern = re.compile(r"(?<!\\)(?:\\\\)*<([A-Za-z][A-Za-z0-9+.-]{1,31}:[^ <>]*?|[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*)>")
     parse_inner = False
 
@@ -197,6 +200,7 @@ class LineBreak(SpanToken):
     """
     Hard or soft line breaks.
     """
+    repr_attributes = ("soft",)
     pattern = re.compile(r'( *|\\)\n')
     parse_inner = False
     parse_group = 0
@@ -276,4 +280,3 @@ class XWikiBlockMacroEnd(SpanToken):
 
 _token_types = []
 reset_tokens()
-

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -26,7 +26,7 @@ class Token:
       is text which occupies the entire horizontal width of the "page" and is
       offset for the surrounding sibling block with line breaks.
 
-    * span_token.SpanToken. for all span-level (or inline-level) tokens.
+    * span_token.SpanToken, for all span-level (or inline-level) tokens.
       A span-level token appears inside the flow of the text lines without any
       surrounding line break.
 

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -29,6 +29,13 @@ class Token:
     * span_token.SpanToken. for all span-level (or inline-level) tokens.
       A span-level token appears inside the flow of the text lines without any
       surrounding line break.
+
+    Custom __repr__ methods in subclasses: The default __repr__ implementation
+    outputs the number of child tokens (from the attribute children) if
+    applicable, and the content attribute if applicable. If any additional
+    attributes should be included in the __repr__ output, this can be specified
+    by setting the class attribute repr_attributes to a tuple containing the
+    attribute names to be output.
     """
 
     repr_attributes = ()

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -2,13 +2,8 @@
 Base token class
 """
 
-import html
-import re
-import mistletoe.span_tokenizer as tokenizer
-from mistletoe import core_tokens
 
-
-def short_repr(value):
+def _short_repr(value):
     """
     Return a shortened repr output of value for use in __repr__ method.
     """
@@ -38,10 +33,10 @@ class Token:
                 output += " with {} children".format(count)
 
         if hasattr(self, "content"):
-           output += " content=" + short_repr(self.content)
+           output += " content=" + _short_repr(self.content)
 
         for attrname in self.repr_attributes:
             attrvalue = getattr(self, attrname)
-            output += " {}={}".format(attrname, short_repr(attrvalue))
+            output += " {}={}".format(attrname, _short_repr(attrvalue))
         output += " at {:#x}>".format(id(self))
         return output

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -1,5 +1,5 @@
 """
-token contains the base token class Token.
+Base token class.
 """
 
 

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -5,7 +5,7 @@ Base token class.
 
 def _short_repr(value):
     """
-    Return a shortened repr output of value for use in __repr__ method.
+    Return a shortened ``repr`` output of value for use in ``__repr__`` methods.
     """
 
     if isinstance(value, str):
@@ -20,22 +20,22 @@ class Token:
     """
     Base token class.
 
-    Token has two subclasses:
+    `Token` has two subclasses:
 
-    * block_token.BlockToken, for all block level tokens. A block level token
+    * `block_token.BlockToken`, for all block level tokens. A block level token
       is text which occupies the entire horizontal width of the "page" and is
       offset for the surrounding sibling block with line breaks.
 
-    * span_token.SpanToken, for all span-level (or inline-level) tokens.
+    * `span_token.SpanToken`, for all span-level (or inline-level) tokens.
       A span-level token appears inside the flow of the text lines without any
       surrounding line break.
 
-    Custom __repr__ methods in subclasses: The default __repr__ implementation
-    outputs the number of child tokens (from the attribute children) if
-    applicable, and the content attribute if applicable. If any additional
-    attributes should be included in the __repr__ output, this can be specified
-    by setting the class attribute repr_attributes to a tuple containing the
-    attribute names to be output.
+    Custom ``__repr__`` methods in subclasses: The default ``__repr__``
+    implementation outputs the number of child tokens (from the attribute
+    ``children``) if applicable, and the ``content`` attribute if applicable.
+    If any additional attributes should be included in the ``__repr__`` output,
+    this can be specified by setting the class attribute ``repr_attributes``
+    to a tuple containing the attribute names to be output.
     """
 
     repr_attributes = ()

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -1,5 +1,5 @@
 """
-Base token class
+token contains the base token class Token.
 """
 
 
@@ -17,6 +17,20 @@ def _short_repr(value):
 
 
 class Token:
+    """
+    Base token class.
+
+    Token has two subclasses:
+
+    * block_token.BlockToken, for all block level tokens. A block level token
+      is text which occupies the entire horizontal width of the "page" and is
+      offset for the surrounding sibling block with line breaks.
+
+    * span_token.SpanToken. for all span-level (or inline-level) tokens.
+      A span-level token appears inside the flow of the text lines without any
+      surrounding line break.
+    """
+
     repr_attributes = ()
 
     def __repr__(self):

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -1,0 +1,47 @@
+"""
+Base token class
+"""
+
+import html
+import re
+import mistletoe.span_tokenizer as tokenizer
+from mistletoe import core_tokens
+
+
+def short_repr(value):
+    """
+    Return a shortened repr output of value for use in __repr__ method.
+    """
+
+    if isinstance(value, str):
+        chars = len(value)
+        threshold = 30
+        if chars > threshold:
+            return "{0!r}...+{1}".format(value[:threshold], chars-threshold)
+    return repr(value)
+
+
+class Token:
+    repr_attributes = ()
+
+    def __repr__(self):
+        output = "<{}.{}".format(
+            self.__class__.__module__,
+            self.__class__.__name__
+        )
+
+        if hasattr(self, "children"):
+            count = len(self.children)
+            if count == 1:
+                output += " with 1 child"
+            else:
+                output += " with {} children".format(count)
+
+        if hasattr(self, "content"):
+           output += " content=" + short_repr(self.content)
+
+        for attrname in self.repr_attributes:
+            attrvalue = getattr(self, attrname)
+            output += " {}={}".format(attrname, short_repr(attrvalue))
+        output += " at {:#x}>".format(id(self))
+        return output

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -80,6 +80,10 @@ class TestRepr(unittest.TestCase):
         doc = Document("~~~foo~~~\n")
         self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Strikethrough with 1 child at 0x")
 
+    def test_image(self):
+        doc = Document("""![Foo](http://www.example.org/ "bar")\n""")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Image with 1 child src='http://www.example.org/' title='bar' at 0x")
+
     def test_link(self):
         doc = Document("[Foo](http://www.example.org/)\n")
         self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Link with 1 child target='http://www.example.org/' title='' at 0x")

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -1,0 +1,105 @@
+from textwrap import dedent
+import unittest
+
+from mistletoe import Document
+from mistletoe.utils import traverse
+
+
+class TestRepr(unittest.TestCase):
+    def check_repr_prefix(self, token, expected_prefix):
+        output = repr(token)[:len(expected_prefix)]
+        self.assertEqual(output, expected_prefix)
+
+    # Block tokens
+
+    def test_document(self):
+        doc = Document("# Foo")
+        self.check_repr_prefix(doc, "<mistletoe.block_token.Document with 1 child at 0x")
+
+    def test_heading(self):
+        doc = Document("# Foo")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Heading with 1 child content='Foo' level=1 at 0x")
+
+    def test_subheading(self):
+        doc = Document("# Foo\n## Bar")
+        self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.Heading with 1 child content='Bar' level=2 at 0x")
+
+    def test_quote(self):
+        doc = Document("> Foo")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Quote with 1 child at 0x")
+
+    def test_paragraph(self):
+        doc = Document("Foo")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Paragraph with 1 child at 0x")
+
+    def test_blockcode(self):
+        doc = Document("Foo\n\n\tBar\n\nBaz")
+        self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.BlockCode with 1 child language='' at 0x")
+
+    def test_codefence(self):
+        doc = Document("""```python\nprint("Hello, World!"\n```""")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.CodeFence with 1 child language='python' at 0x")
+
+    def test_unordered_list(self):
+        doc = Document("* Foo\n* Bar\n* Baz")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.List with 3 children loose=False start=None at 0x")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.block_token.ListItem with 1 child leader='*' prepend=2 loose=False at 0x")
+
+    def test_ordered_list(self):
+        doc = Document("1. Foo\n2. Bar\n3. Baz")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.List with 3 children loose=False start=1 at 0x")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.block_token.ListItem with 1 child leader='1.' prepend=3 loose=False at 0x")
+
+    def test_table(self):
+        doc = Document("| Foo | Bar | Baz |\n|:--- |:---:| ---:|\n| Foo | Bar | Baz |\n")
+        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Table with 1 child column_align=[None, 0, 1] at 0x")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.block_token.TableRow with 3 children row_align=[None, 0, 1] at 0x")
+        self.check_repr_prefix(doc.children[0].children[0].children[0], "<mistletoe.block_token.TableCell with 1 child align=None at 0x")
+
+    def test_thematicbreak(self):
+        doc = Document("Foo\n\n---\n\nBar\n")
+        self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.ThematicBreak at 0x")
+
+    # No tests for ``FootNote`` and ``HTMLBlock``
+
+    # Span tokens
+
+    def test_strong(self):
+        doc = Document("**foo**\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Strong with 1 child at 0x")
+
+    def test_emphasis(self):
+        doc = Document("*foo*\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Emphasis with 1 child at 0x")
+
+    def test_inlinecode(self):
+        doc = Document("`foo`\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.InlineCode with 1 child at 0x")
+
+    def test_strikethrough(self):
+        doc = Document("~~~foo~~~\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Strikethrough with 1 child at 0x")
+
+    def test_link(self):
+        doc = Document("[Foo](http://www.example.org/)\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Link with 1 child target='http://www.example.org/' title='' at 0x")
+
+    def test_autolink(self):
+        doc = Document("Foo <http://www.example.org/>\n")
+        self.check_repr_prefix(doc.children[0].children[1], "<mistletoe.span_token.AutoLink with 1 child target='http://www.example.org/' mailto=False at 0x")
+
+    def test_escapesequence(self):
+        doc = Document("\\*\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.EscapeSequence with 1 child at 0x")
+
+    def test_soft_linebreak(self):
+        doc = Document("Foo\nBar\n")
+        self.check_repr_prefix(doc.children[0].children[1], "<mistletoe.span_token.LineBreak content='' soft=True at 0x")
+
+    def test_hard_linebreak(self):
+        doc = Document("Foo\\\nBar\n")
+        self.check_repr_prefix(doc.children[0].children[1], "<mistletoe.span_token.LineBreak content='' soft=False at 0x")
+
+    def test_rawtext(self):
+        doc = Document("Foo\n")
+        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.RawText content='Foo' at 0x")

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -1,112 +1,113 @@
-import unittest
+import re, unittest
 
 from mistletoe import Document
 from mistletoe import block_token
 
 
 class TestRepr(unittest.TestCase):
-    def check_repr_prefix(self, token, expected_prefix):
-        output = repr(token)[:len(expected_prefix)]
-        self.assertEqual(output, expected_prefix)
+    def _check_repr_matches(self, token, expected_match):
+        expected_match = "<mistletoe.{} at 0x".format(expected_match)
+        output = repr(token)[:len(expected_match)]
+        self.assertEqual(output, expected_match)
 
     # Block tokens
 
     def test_document(self):
         doc = Document("# Foo")
-        self.check_repr_prefix(doc, "<mistletoe.block_token.Document with 1 child at 0x")
+        self._check_repr_matches(doc, "block_token.Document with 1 child")
 
     def test_heading(self):
         doc = Document("# Foo")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Heading with 1 child content='Foo' level=1 at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.Heading with 1 child content='Foo' level=1")
 
     def test_subheading(self):
         doc = Document("# Foo\n## Bar")
-        self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.Heading with 1 child content='Bar' level=2 at 0x")
+        self._check_repr_matches(doc.children[1], "block_token.Heading with 1 child content='Bar' level=2")
 
     def test_quote(self):
         doc = Document("> Foo")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Quote with 1 child at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.Quote with 1 child")
 
     def test_paragraph(self):
         doc = Document("Foo")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Paragraph with 1 child at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.Paragraph with 1 child")
 
     def test_blockcode(self):
         doc = Document("Foo\n\n\tBar\n\nBaz")
-        self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.BlockCode with 1 child language='' at 0x")
+        self._check_repr_matches(doc.children[1], "block_token.BlockCode with 1 child language=''")
 
     def test_codefence(self):
         doc = Document("""```python\nprint("Hello, World!"\n```""")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.CodeFence with 1 child language='python' at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.CodeFence with 1 child language='python'")
 
     def test_unordered_list(self):
         doc = Document("* Foo\n* Bar\n* Baz")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.List with 3 children loose=False start=None at 0x")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.block_token.ListItem with 1 child leader='*' prepend=2 loose=False at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.List with 3 children loose=False start=None")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='*' prepend=2 loose=False")
 
     def test_ordered_list(self):
         doc = Document("1. Foo\n2. Bar\n3. Baz")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.List with 3 children loose=False start=1 at 0x")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.block_token.ListItem with 1 child leader='1.' prepend=3 loose=False at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.List with 3 children loose=False start=1")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='1.' prepend=3 loose=False")
 
     def test_table(self):
         doc = Document("| Foo | Bar | Baz |\n|:--- |:---:| ---:|\n| Foo | Bar | Baz |\n")
-        self.check_repr_prefix(doc.children[0], "<mistletoe.block_token.Table with 1 child column_align=[None, 0, 1] at 0x")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.block_token.TableRow with 3 children row_align=[None, 0, 1] at 0x")
-        self.check_repr_prefix(doc.children[0].children[0].children[0], "<mistletoe.block_token.TableCell with 1 child align=None at 0x")
+        self._check_repr_matches(doc.children[0], "block_token.Table with 1 child column_align=[None, 0, 1]")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.TableRow with 3 children row_align=[None, 0, 1]")
+        self._check_repr_matches(doc.children[0].children[0].children[0], "block_token.TableCell with 1 child align=None")
 
     def test_thematicbreak(self):
         doc = Document("Foo\n\n---\n\nBar\n")
-        self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.ThematicBreak at 0x")
+        self._check_repr_matches(doc.children[1], "block_token.ThematicBreak")
 
     # No test for ``Footnote``
 
     def test_htmlblock(self):
         token = block_token.HTMLBlock("<pre>\nFoo\n</pre>\n")
-        self.check_repr_prefix(token, "<mistletoe.block_token.HTMLBlock content='<pre>\\nFoo\\n</pre>' at 0x")
+        self._check_repr_matches(token, "block_token.HTMLBlock content='<pre>\\nFoo\\n</pre>'")
 
     # Span tokens
 
     def test_strong(self):
         doc = Document("**foo**\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Strong with 1 child at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.Strong with 1 child")
 
     def test_emphasis(self):
         doc = Document("*foo*\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Emphasis with 1 child at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.Emphasis with 1 child")
 
     def test_inlinecode(self):
         doc = Document("`foo`\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.InlineCode with 1 child at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.InlineCode with 1 child")
 
     def test_strikethrough(self):
         doc = Document("~~~foo~~~\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Strikethrough with 1 child at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.Strikethrough with 1 child")
 
     def test_image(self):
         doc = Document("""![Foo](http://www.example.org/ "bar")\n""")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Image with 1 child src='http://www.example.org/' title='bar' at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.Image with 1 child src='http://www.example.org/' title='bar'")
 
     def test_link(self):
         doc = Document("[Foo](http://www.example.org/)\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.Link with 1 child target='http://www.example.org/' title='' at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.Link with 1 child target='http://www.example.org/' title=''")
 
     def test_autolink(self):
         doc = Document("Foo <http://www.example.org/>\n")
-        self.check_repr_prefix(doc.children[0].children[1], "<mistletoe.span_token.AutoLink with 1 child target='http://www.example.org/' mailto=False at 0x")
+        self._check_repr_matches(doc.children[0].children[1], "span_token.AutoLink with 1 child target='http://www.example.org/' mailto=False")
 
     def test_escapesequence(self):
         doc = Document("\\*\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.EscapeSequence with 1 child at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.EscapeSequence with 1 child")
 
     def test_soft_linebreak(self):
         doc = Document("Foo\nBar\n")
-        self.check_repr_prefix(doc.children[0].children[1], "<mistletoe.span_token.LineBreak content='' soft=True at 0x")
+        self._check_repr_matches(doc.children[0].children[1], "span_token.LineBreak content='' soft=True")
 
     def test_hard_linebreak(self):
         doc = Document("Foo\\\nBar\n")
-        self.check_repr_prefix(doc.children[0].children[1], "<mistletoe.span_token.LineBreak content='' soft=False at 0x")
+        self._check_repr_matches(doc.children[0].children[1], "span_token.LineBreak content='' soft=False")
 
     def test_rawtext(self):
         doc = Document("Foo\n")
-        self.check_repr_prefix(doc.children[0].children[0], "<mistletoe.span_token.RawText content='Foo' at 0x")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.RawText content='Foo'")

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -1,8 +1,7 @@
-from textwrap import dedent
 import unittest
 
 from mistletoe import Document
-from mistletoe.utils import traverse
+from mistletoe import block_token
 
 
 class TestRepr(unittest.TestCase):
@@ -60,7 +59,11 @@ class TestRepr(unittest.TestCase):
         doc = Document("Foo\n\n---\n\nBar\n")
         self.check_repr_prefix(doc.children[1], "<mistletoe.block_token.ThematicBreak at 0x")
 
-    # No tests for ``FootNote`` and ``HTMLBlock``
+    # No test for ``Footnote``
+
+    def test_htmlblock(self):
+        token = block_token.HTMLBlock("<pre>\nFoo\n</pre>\n")
+        self.check_repr_prefix(token, "<mistletoe.block_token.HTMLBlock content='<pre>\\nFoo\\n</pre>' at 0x")
 
     # Span tokens
 


### PR DESCRIPTION
This pull request adds a `__repr__` method to all token classes. To simplify implementation it introduces a common base class `token.Token` for `block_token.BlockToken` and `span_taken.SpanToken`. For the following example program:

```python
from mistletoe import block_token, span_token, utils
d = block_token.Document(open("test/samples/quotes.md", "r").read())
print([tr.node for tr in utils.traverse(d)])
```

The output looks like this without `__repr__` methods:

```
[<mistletoe.block_token.Heading at 0x10fa5aec0>,
 <mistletoe.block_token.Quote at 0x10f99e2c0>,
 <mistletoe.block_token.Paragraph at 0x10fb95a50>,
 <mistletoe.block_token.Quote at 0x10fb94130>,
 <mistletoe.block_token.Paragraph at 0x10fb97970>,
 <mistletoe.block_token.Quote at 0x10fb94c10>,
 <mistletoe.block_token.Paragraph at 0x10fbc00d0>,
 <mistletoe.block_token.Quote at 0x10fbc0d30>,
 <mistletoe.block_token.Paragraph at 0x10fbc1270>,
 <mistletoe.span_token.RawText at 0x10fa5b4f0>,
 <mistletoe.block_token.Paragraph at 0x10f99d8a0>,
 <mistletoe.span_token.RawText at 0x10fb95a20>,
 <mistletoe.block_token.Paragraph at 0x10fb97910>,
 <mistletoe.block_token.Paragraph at 0x10fb97c70>,
 <mistletoe.span_token.RawText at 0x10fb97ca0>,
 <mistletoe.block_token.List at 0x10fbc0c40>,
 <mistletoe.span_token.RawText at 0x10fbc0580>,
 <mistletoe.block_token.Quote at 0x10fbc0850>,
 <mistletoe.block_token.Paragraph at 0x10fbc0fd0>,
 <mistletoe.block_token.Quote at 0x10fbc1090>,
 <mistletoe.span_token.RawText at 0x10fbc12a0>,
 <mistletoe.span_token.RawText at 0x10f99cd60>,
 <mistletoe.span_token.RawText at 0x10fb94160>,
 <mistletoe.span_token.RawText at 0x10fb948b0>,
 <mistletoe.block_token.ListItem at 0x10fbc0880>,
 <mistletoe.block_token.ListItem at 0x10fbc03d0>,
 <mistletoe.block_token.Paragraph at 0x10fbc0f10>,
 <mistletoe.span_token.RawText at 0x10fbc1000>,
 <mistletoe.block_token.Paragraph at 0x10fbc10f0>,
 <mistletoe.block_token.Paragraph at 0x10fbc11b0>,
 <mistletoe.block_token.Paragraph at 0x10fbc04f0>,
 <mistletoe.block_token.Paragraph at 0x10fbc0460>,
 <mistletoe.span_token.RawText at 0x10fbc0f70>,
 <mistletoe.span_token.RawText at 0x10fbc1120>,
 <mistletoe.span_token.RawText at 0x10fbc11e0>,
 <mistletoe.span_token.RawText at 0x10fbc0640>,
 <mistletoe.span_token.RawText at 0x10fbc0040>]
```

and like this with `__repr__` methods:

```
[<mistletoe.block_token.Heading with 1 child content='Quotes' level=2 at 0x10f748c40>,
 <mistletoe.block_token.Quote with 1 child at 0x10f748250>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f776830>,
 <mistletoe.block_token.Quote with 2 children at 0x10f7748b0>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f777310>,
 <mistletoe.block_token.Quote with 1 child at 0x10f774220>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f776440>,
 <mistletoe.block_token.Quote with 3 children at 0x10f7b9c90>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f7b82e0>,
 <mistletoe.span_token.RawText content='Quotes' at 0x10f748340>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f664a90>,
 <mistletoe.span_token.RawText content='A response to single quote.' at 0x10f776ec0>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f774370>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f777490>,
 <mistletoe.span_token.RawText content='Quote with a list inside:' at 0x10f7776d0>,
 <mistletoe.block_token.List with 2 children loose=False start=1 at 0x10f7762f0>,
 <mistletoe.span_token.RawText content='Nested quotes:' at 0x10f7b9150>,
 <mistletoe.block_token.Quote with 1 child at 0x10f7ba410>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f7b8580>,
 <mistletoe.block_token.Quote with 2 children at 0x10f7b8b50>,
 <mistletoe.span_token.RawText content='Another paragraph.' at 0x10f7b8be0>,
 <mistletoe.span_token.RawText content='A single quote' at 0x10f665060>,
 <mistletoe.span_token.RawText content='A quote spreading...' at 0x10f777be0>,
 <mistletoe.span_token.RawText content='... multiple paragraphs' at 0x10f776bc0>,
 <mistletoe.block_token.ListItem with 1 child leader='1.' prepend=3 loose=False at 0x10f775d50>,
 <mistletoe.block_token.ListItem with 1 child leader='2.' prepend=3 loose=False at 0x10f776d40>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f7ba3e0>,
 <mistletoe.span_token.RawText content='Quoted paragraph.' at 0x10f7b8460>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f7b9570>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f7b9ae0>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f7749a0>,
 <mistletoe.block_token.Paragraph with 1 child at 0x10f776b30>,
 <mistletoe.span_token.RawText content='Nested line quote' at 0x10f7b8640>,
 <mistletoe.span_token.RawText content='Nested block quote.' at 0x10f7b86a0>,
 <mistletoe.span_token.RawText content='Jira does not seem to support '...+51 at 0x10f7b93f0>,
 <mistletoe.span_token.RawText content='first' at 0x10f776260>,
 <mistletoe.span_token.RawText content='second' at 0x10f7771c0>]
 ```
