### PR TITLE
use void tags as per HTML5 spec

### DIFF
--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -63,7 +63,7 @@ class HTMLRenderer(BaseRenderer):
         return template.format(self.render_inner(token))
 
     def render_image(self, token: span_token.Image) -> str:
-        template = '<img src="{}" alt="{}"{} />'
+        template = '<img src="{}" alt="{}"{}>'
         if token.title:
             title = ' title="{}"'.format(html.escape(token.title))
         else:
@@ -188,11 +188,11 @@ class HTMLRenderer(BaseRenderer):
 
     @staticmethod
     def render_thematic_break(token: block_token.ThematicBreak) -> str:
-        return '<hr />'
+        return '<hr>'
 
     @staticmethod
     def render_line_break(token: span_token.LineBreak) -> str:
-        return '\n' if token.soft else '<br />\n'
+        return '\n' if token.soft else '<br>\n'
 
     @staticmethod
     def render_html_block(token: block_token.HTMLBlock) -> str:


### PR DESCRIPTION
A small suggestion to be compliant with https://html.spec.whatwg.org/multipage/syntax.html#void-elements. Void elements don't need the closing slash.