### PR TITLE
refactor: remove unused imports and variables (#146)

### DIFF
--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -21,12 +21,10 @@
 # SOFTWARE.
 #
 
-import html
 from itertools import chain
 from mistletoe import block_token, span_token
 from mistletoe.base_renderer import BaseRenderer
 import re
-import sys
 
 class JIRARenderer(BaseRenderer):
     """
@@ -61,7 +59,7 @@ class JIRARenderer(BaseRenderer):
 
     def render_image(self, token):
         template = '!{src}!'
-        inner = self.render_inner(token)
+        self.render_inner(token)
         return template.format(src=token.src)
 
     def render_link(self, token):

--- a/contrib/md2jira.py
+++ b/contrib/md2jira.py
@@ -25,8 +25,6 @@
 import os
 import sys
 import getopt
-import subprocess
-import shutil
 import mistletoe
 from contrib.jira_renderer import JIRARenderer
 

--- a/contrib/scheme.py
+++ b/contrib/scheme.py
@@ -13,7 +13,6 @@ class Expr(span_token.SpanToken):
     @classmethod
     def find(cls, string):
         matches = []
-        count = 0
         start = []
         for i, c in enumerate(string):
             if c == '(':

--- a/contrib/toc_renderer.py
+++ b/contrib/toc_renderer.py
@@ -31,7 +31,6 @@ class TOCRenderer(HTMLRenderer):
         """
         Returns table of contents as a block_token.List instance.
         """
-        from mistletoe.block_token import List
         def get_indent(level):
             if self.omit_title:
                 level -= 1

--- a/contrib/xwiki20_renderer.py
+++ b/contrib/xwiki20_renderer.py
@@ -19,11 +19,9 @@
 # SOFTWARE.
 #
 
-import html
 from itertools import chain
 from mistletoe import block_token, span_token
 from mistletoe.base_renderer import BaseRenderer
-import sys
 
 class XWiki20Renderer(BaseRenderer):
     """
@@ -63,7 +61,7 @@ class XWiki20Renderer(BaseRenderer):
 
     def render_image(self, token):
         template = '[[image:{src}]]'
-        inner = self.render_inner(token)
+        self.render_inner(token)
         return template.format(src=token.src)
 
     def render_link(self, token):

--- a/mistletoe/__init__.py
+++ b/mistletoe/__init__.py
@@ -7,7 +7,6 @@ __all__ = ['html_renderer', 'ast_renderer', 'block_token', 'block_tokenizer',
            'span_token', 'span_tokenizer']
 
 from mistletoe.block_token import Document
-from mistletoe.base_renderer import BaseRenderer
 from mistletoe.html_renderer import HTMLRenderer
 
 def markdown(iterable, renderer=HTMLRenderer):

--- a/mistletoe/base_renderer.py
+++ b/mistletoe/base_renderer.py
@@ -3,7 +3,6 @@ Base class for renderers.
 """
 
 import re
-import sys
 from mistletoe import block_token, span_token
 
 class BaseRenderer(object):

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -3,12 +3,10 @@ Built-in block-level token classes.
 """
 
 import re
-import sys
 from itertools import zip_longest
 import mistletoe.block_tokenizer as tokenizer
 from mistletoe import token, span_token
 from mistletoe.core_tokens import (
-        is_link_label,
         follows,
         shift_whitespace,
         whitespace,

--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -4,7 +4,6 @@ HTML renderer for mistletoe.
 
 import html
 import re
-import sys
 from itertools import chain
 from urllib.parse import quote
 from mistletoe import block_token

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -60,7 +60,7 @@ class TestSetextHeading(TestToken):
         self.assertIsInstance(next(tokens), block_token.Paragraph)
         self.mock.assert_has_calls([call('some'), call('heading'), call('foobar')])
         with self.assertRaises(StopIteration) as e:
-            token = next(tokens)
+            next(tokens)
 
 
 class TestQuote(unittest.TestCase):
@@ -177,7 +177,6 @@ class TestListItem(unittest.TestCase):
         lines = ['- foo\n',
                  '  - bar\n',
                  '    - baz\n']
-        f = FileWrapper(lines)
         ptoken, ltoken = block_token.tokenize(lines)[0].children[0].children
         self.assertIsInstance(ptoken, block_token.Paragraph)
         self.assertIsInstance(ltoken, block_token.List)
@@ -195,7 +194,6 @@ class TestListItem(unittest.TestCase):
                  '  \n',
                  '  baz\n'
                  '  ~~~\n']
-        f = FileWrapper(lines)
         list_item = block_token.tokenize(lines)[0].children[0]
         self.assertEqual(list_item.loose, False)
 
@@ -203,7 +201,6 @@ class TestListItem(unittest.TestCase):
         lines = ['- foo\n',
                  '\n',
                  '# bar\n']
-        f = FileWrapper(lines)
         list_item = block_token.tokenize(lines)[0].children[0]
         self.assertEqual(list_item.loose, False)
 

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -20,11 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest import TestCase, mock
 from test.base_test import BaseRendererTest
-from mistletoe.block_token import Document
 from mistletoe.span_token import tokenize_inner
-from mistletoe import Document
 from contrib.jira_renderer import JIRARenderer
 import random
 import string

--- a/test/test_contrib/test_toc_renderer.py
+++ b/test/test_contrib/test_toc_renderer.py
@@ -13,7 +13,7 @@ class TestTOCRenderer(TestCase):
         renderer = TOCRenderer()
         Heading.start('### some *text*\n')
         token = Heading(Heading.read(iter(['foo'])))
-        rendered_heading = renderer.render_heading(token)
+        renderer.render_heading(token)
         self.assertEqual(renderer._headings[0], (3, 'some text'))
 
     def test_depth(self):

--- a/test/test_contrib/test_xwiki20_renderer.py
+++ b/test/test_contrib/test_xwiki20_renderer.py
@@ -18,11 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest import TestCase, mock
 from test.base_test import BaseRendererTest
-from mistletoe.block_token import Document
 from mistletoe.span_token import tokenize_inner
-from mistletoe import Document
 from contrib.xwiki20_renderer import XWiki20Renderer
 import random
 import string

--- a/test/test_core_tokens.py
+++ b/test/test_core_tokens.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from unittest.mock import patch
 from mistletoe.core_tokens import (MatchObj, Delimiter, follows, shift_whitespace,
         is_control_char, deactivate_delimiters, preceded_by, succeeded_by)
 

--- a/test/test_latex_renderer.py
+++ b/test/test_latex_renderer.py
@@ -1,5 +1,4 @@
 from unittest import TestCase, mock
-import mistletoe.latex_token as latex_token
 from mistletoe.latex_renderer import LaTeXRenderer
 from mistletoe import markdown
 

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -1,4 +1,4 @@
-import re, unittest
+import unittest
 
 from mistletoe import Document
 from mistletoe import block_token

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import patch
 from mistletoe import span_token
-from functools import wraps
 
 
 class TestBranchToken(unittest.TestCase):


### PR DESCRIPTION
Removing all unused stuff identified by running:

    autoflake --remove-all-unused-imports --remove-unused-variables -r -i .