### PR TITLE
Ensure LaTeX renderer uses valid \verb delimiter

### DIFF
--- a/mistletoe/latex_renderer.py
+++ b/mistletoe/latex_renderer.py
@@ -5,6 +5,16 @@ LaTeX renderer for mistletoe.
 from itertools import chain
 import mistletoe.latex_token as latex_token
 from mistletoe.base_renderer import BaseRenderer
+import string
+
+
+# (customizable) delimiters for inline code
+verb_delimiters = string.punctuation + string.digits
+for delimiter in '*':  # remove invalid delimiters
+    verb_delimiters.replace(delimiter, '')
+for delimiter in reversed('|!"\'=+'):  # start with most common delimiters
+    verb_delimiters = delimiter + verb_delimiters.replace(delimiter, '')
+
 
 class LaTeXRenderer(BaseRenderer):
     def __init__(self, *extras):
@@ -14,6 +24,7 @@ class LaTeXRenderer(BaseRenderer):
         """
         tokens = self._tokens_from_module(latex_token)
         self.packages = {}
+        self.verb_delimiters = verb_delimiters
         super().__init__(*chain(tokens, extras))
 
     def render_strong(self, token):
@@ -26,7 +37,7 @@ class LaTeXRenderer(BaseRenderer):
         content = self.render_raw_text(token.children[0], escape=False)
 
         # search for delimiter not present in content
-        for delimiter in list('|+=!@#$^&`~-_:'):
+        for delimiter in self.verb_delimiters:
             if delimiter not in content:
                 break
 

--- a/mistletoe/latex_renderer.py
+++ b/mistletoe/latex_renderer.py
@@ -23,7 +23,18 @@ class LaTeXRenderer(BaseRenderer):
         return '\\textit{{{}}}'.format(self.render_inner(token))
 
     def render_inline_code(self, token):
-        return '\\verb|{}|'.format(self.render_raw_text(token.children[0], escape=False))
+        content = self.render_raw_text(token.children[0], escape=False)
+
+        # search for delimiter not present in content
+        for delimiter in list('|+=!@#$^&`~-_:'):
+            if delimiter not in content:
+                break
+
+        if delimiter in content:  # no delimiter found
+            raise RuntimeError('Unable to find delimiter for verb macro')
+
+        template = '\\verb{delimiter}{content}{delimiter}'
+        return template.format(delimiter=delimiter, content=content)
 
     def render_strikethrough(self, token):
         self.packages['ulem'] = ['normalem']

--- a/test/test_latex_renderer.py
+++ b/test/test_latex_renderer.py
@@ -28,8 +28,19 @@ class TestLaTeXRenderer(TestCase):
 
     def test_inline_code(self):
         func_path = 'mistletoe.latex_renderer.LaTeXRenderer.render_raw_text'
-        with mock.patch(func_path, return_value='inner'):
-            self._test_token('InlineCode', '\\verb|inner|')
+
+        for content, output in {'inner': '\\verb|inner|',
+                                'a + b': '\\verb|a + b|',
+                                'a | b': '\\verb+a | b+',
+                                '|a + b|': '\\verb=|a + b|=',
+                               }.items():
+            with mock.patch(func_path, return_value=content):
+                self._test_token('InlineCode', output, content=content)
+
+        content = '|+=!@#$^&`~-_:'
+        with self.assertRaises(RuntimeError):
+            with mock.patch(func_path, return_value=content):
+                self._test_token('InlineCode', None, content=content)
 
     def test_strikethrough(self):
         self._test_token('Strikethrough', '\\sout{inner}')

--- a/test/test_latex_renderer.py
+++ b/test/test_latex_renderer.py
@@ -1,4 +1,5 @@
 from unittest import TestCase, mock
+import mistletoe.latex_renderer
 from mistletoe.latex_renderer import LaTeXRenderer
 from mistletoe import markdown
 
@@ -31,13 +32,13 @@ class TestLaTeXRenderer(TestCase):
 
         for content, output in {'inner': '\\verb|inner|',
                                 'a + b': '\\verb|a + b|',
-                                'a | b': '\\verb+a | b+',
-                                '|a + b|': '\\verb=|a + b|=',
+                                'a | b': '\\verb!a | b!',
+                                '|ab!|': '\\verb"|ab!|"',
                                }.items():
             with mock.patch(func_path, return_value=content):
                 self._test_token('InlineCode', output, content=content)
 
-        content = '|+=!@#$^&`~-_:'
+        content = mistletoe.latex_renderer.verb_delimiters
         with self.assertRaises(RuntimeError):
             with mock.patch(func_path, return_value=content):
                 self._test_token('InlineCode', None, content=content)


### PR DESCRIPTION
The LaTeX renderer uses `\verb` for inline code, but the delimiter is
always a vertical bar, which produces incorrect output when the inline
code also contains a vertical bar (e.g., `example | pipe`).

Rather than using a single static character (i.e., a vertical bar),
this change modifies render_inline_code to search for a non-letter
delimiter that does not appear in the inline code. If no such
delimiter can be found, a RuntimeError is raised to avoid incorrect
output.

Note that the list of possible delimiters is not exhaustive. For
example, numbers (0, 1, 2, etc.) are all valid delimiters for \verb
but are omitted from the search.

Fixes #149