### PR TITLE
Improved some docstrings

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -189,8 +189,11 @@ class SetextHeading(BlockToken):
     """
     Setext heading token.
     This is a leaf block token. Its children are inline (span) tokens.
-    
+
     Not included in the parsing process, but called by Paragraph.__new__.
+
+    Attributes:
+        level (int): heading level.
     """
     repr_attributes = ("level",)
     def __init__(self, lines):

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -907,7 +907,7 @@ class Footnote(BlockToken):
 class ThematicBreak(BlockToken):
     """
     Thematic break token (a.k.a. horizontal rule.)
-    This is a leaf block token. Its children are inline (span) tokens.
+    This is a leaf block token without children.
     """
     pattern = re.compile(r' {0,3}(?:([-_*])\s*?)(?:\1\s*?){2,}$')
     def __init__(self, _):

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -136,6 +136,7 @@ class BlockToken(token.Token):
 class Document(BlockToken):
     """
     Document token.
+    This is a container block token. Its children are block tokens, container or leaf.
     """
     def __init__(self, lines):
         if isinstance(lines, str):
@@ -152,7 +153,8 @@ class Document(BlockToken):
 
 class Heading(BlockToken):
     """
-    Heading token. (["### some heading ###\\n"])
+    ATX heading token. (["### some heading ###\\n"])
+    This is a leaf block token. Its children are inline (span) tokens.
     Boundary between span-level and block-level tokens.
 
     Attributes:
@@ -186,7 +188,8 @@ class Heading(BlockToken):
 
 class SetextHeading(BlockToken):
     """
-    Setext headings.
+    Setext heading token.
+    This is a leaf block token. Its children are inline (span) tokens.
     
     Not included in the parsing process, but called by Paragraph.__new__.
     """
@@ -207,7 +210,8 @@ class SetextHeading(BlockToken):
 
 class Quote(BlockToken):
     """
-    Quote token. (["> # heading\\n", "> paragraph\\n"])
+    Block quote token. (["> # heading\\n", "> paragraph\\n"])
+    This is a container block token. Its children are block tokens, container or leaf.
     """
     def __init__(self, parse_buffer):
         # span-level tokenizing happens here.
@@ -288,6 +292,7 @@ class Quote(BlockToken):
 class Paragraph(BlockToken):
     """
     Paragraph token. (["some\\n", "continuous\\n", "lines\\n"])
+    This is a leaf block token. Its children are inline (span) tokens.
     Boundary between span-level and block-level tokens.
     """
     setext_pattern = re.compile(r' {0,3}(=|-)+ *$')
@@ -354,7 +359,8 @@ class Paragraph(BlockToken):
 
 class BlockCode(BlockToken):
     """
-    Indented code.
+    Indented code block token.
+    This is a leaf block token with a single child of type span_token.RawText.
 
     Attributes:
         children (list): contains a single span_token.RawText token.
@@ -399,7 +405,8 @@ class BlockCode(BlockToken):
 
 class CodeFence(BlockToken):
     """
-    Code fence. (["```sh\\n", "rm -rf /", ..., "```"])
+    Fenced code block token. (["```sh\\n", "rm -rf /", ..., "```"])
+    This is a leaf block token with a single child of type span_token.RawText.
     Boundary between span-level and block-level tokens.
 
     Attributes:
@@ -445,6 +452,7 @@ class CodeFence(BlockToken):
 class List(BlockToken):
     """
     List token.
+    This is a container block token. Its children are list item tokens.
 
     Attributes:
         children (list): a list of ListItem tokens.
@@ -498,9 +506,11 @@ class List(BlockToken):
 
 class ListItem(BlockToken):
     """
-    List items. Not included in the parsing process, but called by List.
-    """
+    List item token.
+    This is a container block token. Its children are block tokens, container or leaf.
 
+    Not included in the parsing process, but called by List.
+    """
     repr_attributes = ("leader", "prepend", "loose")
     pattern = re.compile(r'\s*(\d{0,9}[.)]|[+\-*])(\s*$|\s+)')
 
@@ -618,6 +628,7 @@ class ListItem(BlockToken):
 class Table(BlockToken):
     """
     Table token.
+    This is a container block token. Its children are table row tokens.
 
     Attributes:
         has_header (bool): whether table has header row.
@@ -679,6 +690,7 @@ class Table(BlockToken):
 class TableRow(BlockToken):
     """
     Table row token. Supports escaped pipes in table cells (for primary use within code spans).
+    This is a container block token. Its children are table cell tokens.
 
     Should only be called by Table.__init__().
     """
@@ -698,6 +710,7 @@ class TableRow(BlockToken):
 class TableCell(BlockToken):
     """
     Table cell token.
+    This is a leaf block token. Its children are inline (span) tokens.
     Boundary between span-level and block-level tokens.
 
     Should only be called by TableRow.__init__().
@@ -715,6 +728,7 @@ class TableCell(BlockToken):
 class Footnote(BlockToken):
     """
     Footnote token. A "link reference definition" according to the spec.
+    This is a leaf block token. Its children are inline (span) tokens.
 
     The constructor returns None, because the footnote information
     is stored in Footnote.read.
@@ -893,6 +907,7 @@ class Footnote(BlockToken):
 class ThematicBreak(BlockToken):
     """
     Thematic break token (a.k.a. horizontal rule.)
+    This is a leaf block token. Its children are inline (span) tokens.
     """
     pattern = re.compile(r' {0,3}(?:([-_*])\s*?)(?:\1\s*?){2,}$')
     def __init__(self, _):
@@ -909,7 +924,7 @@ class ThematicBreak(BlockToken):
 
 class HTMLBlock(BlockToken):
     """
-    Block-level HTML tokens.
+    Block-level HTML token.
 
     Attributes:
         content (str): literal strings rendered as-is.

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -155,7 +155,6 @@ class Heading(BlockToken):
     """
     ATX heading token. (["### some heading ###\\n"])
     This is a leaf block token. Its children are inline (span) tokens.
-    Boundary between span-level and block-level tokens.
 
     Attributes:
         level (int): heading level.
@@ -293,7 +292,6 @@ class Paragraph(BlockToken):
     """
     Paragraph token. (["some\\n", "continuous\\n", "lines\\n"])
     This is a leaf block token. Its children are inline (span) tokens.
-    Boundary between span-level and block-level tokens.
     """
     setext_pattern = re.compile(r' {0,3}(=|-)+ *$')
     parse_setext = True  # can be disabled by Quote
@@ -407,7 +405,6 @@ class CodeFence(BlockToken):
     """
     Fenced code block token. (["```sh\\n", "rm -rf /", ..., "```"])
     This is a leaf block token with a single child of type span_token.RawText.
-    Boundary between span-level and block-level tokens.
 
     Attributes:
         children (list): contains a single span_token.RawText token.
@@ -711,7 +708,6 @@ class TableCell(BlockToken):
     """
     Table cell token.
     This is a leaf block token. Its children are inline (span) tokens.
-    Boundary between span-level and block-level tokens.
 
     Should only be called by TableRow.__init__().
 

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -921,9 +921,10 @@ class ThematicBreak(BlockToken):
 class HTMLBlock(BlockToken):
     """
     Block-level HTML token.
+    This is a leaf block token without children.
 
     Attributes:
-        content (str): literal strings rendered as-is.
+        content (str): the raw HTML content.
     """
     _end_cond = None
     multiblock = re.compile(r'<(script|pre|style)[ >\n]')

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -136,7 +136,7 @@ class BlockToken(token.Token):
 class Document(BlockToken):
     """
     Document token.
-    This is a container block token. Its children are block tokens, container or leaf.
+    This is a container block token. Its children are block tokens - container or leaf ones.
     """
     def __init__(self, lines):
         if isinstance(lines, str):
@@ -211,7 +211,7 @@ class SetextHeading(BlockToken):
 class Quote(BlockToken):
     """
     Block quote token. (["> # heading\\n", "> paragraph\\n"])
-    This is a container block token. Its children are block tokens, container or leaf.
+    This is a container block token. Its children are block tokens - container or leaf ones.
     """
     def __init__(self, parse_buffer):
         # span-level tokenizing happens here.
@@ -507,7 +507,7 @@ class List(BlockToken):
 class ListItem(BlockToken):
     """
     List item token.
-    This is a container block token. Its children are block tokens, container or leaf.
+    This is a container block token. Its children are block tokens - container or leaf ones.
 
     Not included in the parsing process, but called by List.
     """

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -144,7 +144,7 @@ class Strikethrough(SpanToken):
 class Image(SpanToken):
     """
     Image token. ("![alt](src "title")")
-    This is an inline token. Its children are inline (span) tokens.
+    This is an inline token. Its children are inline (span) tokens holding the image description.
     One of the core tokens.
 
     Attributes:
@@ -160,11 +160,12 @@ class Image(SpanToken):
 class Link(SpanToken):
     """
     Link token. ("[name](target)")
-    This is an inline token. Its children are inline (span) tokens.
+    This is an inline token. Its children are inline (span) tokens holding the link text.
     One of the core tokens.
 
     Attributes:
         target (str): link target.
+        title (str): link title (default to empty).
     """
     repr_attributes = ("target", "title")
     def __init__(self, match):

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -198,7 +198,7 @@ class EscapeSequence(SpanToken):
     This is an inline token with a single child of type RawText.
 
     Attributes:
-        children (iterator): a single RawText node for alternative text.
+        children (iterator): a single RawText node containing the escaped character.
     """
     pattern = re.compile(r"\\([!\"#$%&'()*+,-./:;<=>?@\[\\\]^_`{|}~])")
     parse_inner = False

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -267,7 +267,7 @@ class HTMLSpan(SpanToken):
     This is an inline token without children.
 
     Attributes:
-        content (str): literal strings rendered as-is.
+        content (str): the raw HTML content.
     """
     pattern = re.compile('|'.join([_open_tag, _closing_tag, _comment,
                                    _instruction, _declaration, _cdata]),

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -84,6 +84,10 @@ class SpanToken(token.Token):
 
 
 class CoreTokens(SpanToken):
+    """
+    Represents core tokens (Strong, Emphasis, Image, Link) during the early stage of parsing.
+    Replaced with objects of the proper classes in the final stage of parsing.
+    """
     precedence = 3
     def __new__(self, match):
         return globals()[match.type](match)
@@ -95,19 +99,24 @@ class CoreTokens(SpanToken):
 
 class Strong(SpanToken):
     """
-    Strong tokens. ("**some text**")
+    Strong token. ("**some text**")
+    This is an inline token. Its children are inline (span) tokens.
+    One of the core tokens.
     """
 
 
 class Emphasis(SpanToken):
     """
-    Emphasis tokens. ("*some text*")
+    Emphasis token. ("*some text*")
+    This is an inline token. Its children are inline (span) tokens.
+    One of the core tokens.
     """
 
 
 class InlineCode(SpanToken):
     """
-    Inline code tokens. ("`some code`")
+    Inline code token. ("`some code`")
+    This is an inline token with a single child of type RawText.
     """
     pattern = re.compile(r"(?<!\\|`)(?:\\\\)*(`+)(?!`)(.+?)(?<!`)\1(?!`)", re.DOTALL)
     parse_inner = False
@@ -126,14 +135,17 @@ class InlineCode(SpanToken):
 
 class Strikethrough(SpanToken):
     """
-    Strikethrough tokens. ("~~some text~~")
+    Strikethrough token. ("~~some text~~")
+    This is an inline token. Its children are inline (span) tokens.
     """
     pattern = re.compile(r"(?<!\\)(?:\\\\)*~~(.+?)~~", re.DOTALL)
 
 
 class Image(SpanToken):
     """
-    Image tokens. ("![alt](src "title")")
+    Image token. ("![alt](src "title")")
+    This is an inline token. Its children are inline (span) tokens.
+    One of the core tokens.
 
     Attributes:
         src (str): image source.
@@ -147,7 +159,9 @@ class Image(SpanToken):
 
 class Link(SpanToken):
     """
-    Link tokens. ("[name](target)")
+    Link token. ("[name](target)")
+    This is an inline token. Its children are inline (span) tokens.
+    One of the core tokens.
 
     Attributes:
         target (str): link target.
@@ -160,10 +174,11 @@ class Link(SpanToken):
 
 class AutoLink(SpanToken):
     """
-    Autolink tokens. ("<http://www.google.com>")
+    Autolink token. ("<http://www.google.com>")
+    This is an inline token with a single child of type RawText.
 
     Attributes:
-        children (iterator): a single RawText node for alternative text.
+        children (iterator): a single RawText node for the link target.
         target (str): link target.
     """
     repr_attributes = ("target", "mailto")
@@ -179,7 +194,8 @@ class AutoLink(SpanToken):
 
 class EscapeSequence(SpanToken):
     """
-    Escape sequences. ("\*")
+    Escape sequence token. ("\*")
+    This is an inline token with a single child of type RawText.
 
     Attributes:
         children (iterator): a single RawText node for alternative text.
@@ -198,7 +214,8 @@ class EscapeSequence(SpanToken):
 
 class LineBreak(SpanToken):
     """
-    Hard or soft line breaks.
+    Line break token. Hard or soft.
+    This is an inline token without children.
     """
     repr_attributes = ("soft",)
     pattern = re.compile(r'( *|\\)\n')
@@ -213,7 +230,8 @@ class LineBreak(SpanToken):
 
 class RawText(SpanToken):
     """
-    Raw text. A leaf node.
+    Raw text token.
+    This is an inline token without children.
 
     RawText is the only token that accepts a string for its constructor,
     instead of a match object. Also, all recursions should bottom out here.
@@ -245,7 +263,8 @@ _cdata       = r'(?<!\\)<!\[CDATA.+?\]\]>'
 
 class HTMLSpan(SpanToken):
     """
-    Span-level HTML tokens.
+    Span-level HTML token.
+    This is an inline token without children.
 
     Attributes:
         content (str): literal strings rendered as-is.


### PR DESCRIPTION
Improved some docstrings:
- mapping between mistletoe and commonmark terminology,
- describing the representation of the content of the tokens.