### PR TITLE
Fix for part of #108, Update to CommonMark v0.30

### DIFF
--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -54,7 +54,10 @@ class HTMLRenderer(BaseRenderer):
 
     def render_inline_code(self, token: span_token.InlineCode) -> str:
         template = '<code>{}</code>'
-        inner = html.escape(token.children[0].content)
+        content = token.children[0].content.replace('\n', ' ')
+        if not content.isspace() and content.startswith(" ") and content.endswith(" "):
+            content = content[1:-1]
+        inner = html.escape(content)
         return template.format(inner)
 
     def render_strikethrough(self, token: span_token.Strikethrough) -> str:

--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -54,10 +54,7 @@ class HTMLRenderer(BaseRenderer):
 
     def render_inline_code(self, token: span_token.InlineCode) -> str:
         template = '<code>{}</code>'
-        content = token.children[0].content.replace('\n', ' ')
-        if not content.isspace() and content.startswith(" ") and content.endswith(" "):
-            content = content[1:-1]
-        inner = html.escape(content)
+        inner = html.escape(token.children[0].content)
         return template.format(inner)
 
     def render_strikethrough(self, token: span_token.Strikethrough) -> str:

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -124,7 +124,7 @@ class InlineCode(SpanToken):
 
     def __init__(self, match):
         content = match.group(self.parse_group)
-        self.children = (RawText(' '.join(re.split('[ \n]+', content.strip()))),)
+        self.children = (RawText(content),)
 
     @classmethod
     def find(cls, string):

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -124,6 +124,9 @@ class InlineCode(SpanToken):
 
     def __init__(self, match):
         content = match.group(self.parse_group)
+        content = content.replace('\n', ' ')
+        if not content.isspace() and content.startswith(" ") and content.endswith(" "):
+            content = content[1:-1]
         self.children = (RawText(content),)
 
     @classmethod

--- a/test/specification/spec.sh
+++ b/test/specification/spec.sh
@@ -2,23 +2,13 @@
 
 set -e
 
-REPO="https://github.com/commonmark/CommonMark.git"
 VERSION="0.28"
+URL="https://spec.commonmark.org/$VERSION/spec.json"
 
 function main {
-    echo "Cloning from repo: $REPO..."
-    git clone --quiet $REPO
-
     echo "Using version $VERSION..."
-    cd "CommonMark"
-    git checkout --quiet $VERSION
 
-    echo "Dumping tests file..."
-    python3 "test/spec_tests.py" --dump-tests > "../commonmark.json"
-
-    echo "Cleaning up..."
-    cd ..
-    rm -rf CommonMark
+    curl -k -o commonmark.json $URL
 
     echo "Done."
 }

--- a/test/test_html_renderer.py
+++ b/test/test_html_renderer.py
@@ -31,6 +31,8 @@ class TestHTMLRenderer(TestRenderer):
         from mistletoe.span_token import tokenize_inner
         rendered = self.renderer.render(tokenize_inner('`foo`')[0])
         self.assertEqual(rendered, '<code>foo</code>')
+        rendered = self.renderer.render(tokenize_inner('`` \\[\\` ``')[0])
+        self.assertEqual(rendered, '<code>\\[\\`</code>')
 
     def test_strikethrough(self):
         self._test_token('Strikethrough', '<del>inner</del>')

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -53,6 +53,14 @@ class TestInlineCode(TestBranchToken):
     def test_parse_in_strikethrough(self):
         self._test_parse_enclosed(span_token.Strikethrough, '~~')
 
+    def test_preserve_space(self):
+        self._test_parse(span_token.InlineCode, '``` ```', ' ')
+        self._test_parse(span_token.InlineCode, '`  ``  `', '  ``  ')
+
+    def test_preserve_escapes(self):
+        self._test_parse(span_token.InlineCode, '`\\xa0b\\xa0`', '\\xa0b\\xa0')
+        self._test_parse(span_token.InlineCode, '`` \\[\\` ``', ' \\[\\` ')
+
 
 class TestStrikethrough(TestBranchToken):
     def test_parse(self):

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -98,10 +98,10 @@ class TestImage(TestBranchToken):
 
 class TestEscapeSequence(TestBranchToken):
     def test_parse(self):
-        self._test_parse(span_token.EscapeSequence, '\*', '*')
+        self._test_parse(span_token.EscapeSequence, r'\*', '*')
 
     def test_parse_in_text(self):
-        tokens = iter(span_token.tokenize_inner('some \*text*'))
+        tokens = iter(span_token.tokenize_inner(r'some \*text*'))
         self._test_token(next(tokens), 'some ', children=False)
         self._test_token(next(tokens), '*')
         self._test_token(next(tokens), 'text*', children=False)

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -53,13 +53,13 @@ class TestInlineCode(TestBranchToken):
     def test_parse_in_strikethrough(self):
         self._test_parse_enclosed(span_token.Strikethrough, '~~')
 
-    def test_preserve_space(self):
+    def test_remove_space_if_present_on_both_sides(self):
         self._test_parse(span_token.InlineCode, '``` ```', ' ')
-        self._test_parse(span_token.InlineCode, '`  ``  `', '  ``  ')
+        self._test_parse(span_token.InlineCode, '`  ``  `', ' `` ')
 
     def test_preserve_escapes(self):
         self._test_parse(span_token.InlineCode, '`\\xa0b\\xa0`', '\\xa0b\\xa0')
-        self._test_parse(span_token.InlineCode, '`` \\[\\` ``', ' \\[\\` ')
+        self._test_parse(span_token.InlineCode, '``\\`\\[``', '\\`\\[')
 
 
 class TestStrikethrough(TestBranchToken):


### PR DESCRIPTION
This PR fixes nine of the failing examples in the CommonMark 0.30 specification. They all had in common that content inside code spans was not handled according to the spec.

This was solved by preserving space and escape sequences during parsing, and by removing leading and trailing space according to the spec during HTML rendering.

The PR also includes a fix for a warning, a simplified way to download the spec tests examples, and an improvement to the spec test runner.