### PR TITLE
fix: Make filtering children by class in traverse() actually work

### DIFF
--- a/mistletoe/utils.py
+++ b/mistletoe/utils.py
@@ -24,7 +24,7 @@ def traverse(source, klass=None, depth=None, include_source=False):
         current_depth += 1
         new_children = []
         for parent, child in next_children:
-            if klass is None or issubclass(child, klass):
+            if klass is None or isinstance(child, klass):
                 yield TraverseResult(child, parent, current_depth)
             new_children.extend(
                 [(child, c) for c in getattr(child, 'children', [])]

--- a/test/test_traverse.py
+++ b/test/test_traverse.py
@@ -2,11 +2,12 @@ from textwrap import dedent
 import unittest
 
 from mistletoe import Document
+from mistletoe.span_token import Strong
 from mistletoe.utils import traverse
 
 
 class TestTraverse(unittest.TestCase):
-    def test_a(self):
+    def test_with_included_source(self):
         doc = Document(
             dedent(
                 """\
@@ -39,3 +40,8 @@ class TestTraverse(unittest.TestCase):
                 ('RawText', 'Emphasis', 4),
             ]
         )
+
+    def test_with_class_filter(self):
+        doc = Document("a **b** c **d**")
+        filtered = [t.node.__class__.__name__ for t in traverse(doc, klass=Strong)]
+        self.assertEqual(filtered, ["Strong", "Strong"])


### PR DESCRIPTION
The `traverse()` utility function was previously written to filter
children by class using `issubclass(child, klass):`. But the first
argument to `issubclass()` must be a class so this will always raise an
exception when trying to use the functionality. This patch corrects the
call to `isinstance(child, klass)` and adds a test.