### PR TITLE
fix: Apply traverse class filter to source when include_source=True

### DIFF
--- a/mistletoe/utils.py
+++ b/mistletoe/utils.py
@@ -12,12 +12,13 @@ def traverse(source, klass=None, depth=None, include_source=False):
         klass: filter children by a certain token class
         depth (int): The depth to recurse into the tree
         include_source (bool): whether to first yield the source element
+                               (provided it passes any given ``klass`` filter)
 
     Yields:
         A container for an element, its parent and depth
     """
     current_depth = 0
-    if include_source:
+    if include_source and (klass is None or isinstance(source, klass)):
         yield TraverseResult(source, None, current_depth)
     next_children = [(source, c) for c in getattr(source, 'children', [])]
     while next_children and (depth is None or current_depth > depth):

--- a/test/test_traverse.py
+++ b/test/test_traverse.py
@@ -7,6 +7,22 @@ from mistletoe.utils import traverse
 
 
 class TestTraverse(unittest.TestCase):
+    def test(self):
+        doc = Document("a **b** c **d**")
+        filtered = [t.node.__class__.__name__ for t in traverse(doc)]
+        self.assertEqual(
+            filtered,
+            [
+                "Paragraph",
+                "RawText",
+                "Strong",
+                "RawText",
+                "Strong",
+                "RawText",
+                "RawText",
+            ],
+        )
+
     def test_with_included_source(self):
         doc = Document(
             dedent(
@@ -45,3 +61,12 @@ class TestTraverse(unittest.TestCase):
         doc = Document("a **b** c **d**")
         filtered = [t.node.__class__.__name__ for t in traverse(doc, klass=Strong)]
         self.assertEqual(filtered, ["Strong", "Strong"])
+
+    def test_with_included_source_and_class_filter(self):
+        doc = Document("a **b** c **d**")
+        filtered = [
+            t.node.__class__.__name__
+            for t in traverse(doc, include_source=True, klass=Strong)
+        ]
+        self.assertEqual(filtered, ["Strong", "Strong"])
+


### PR DESCRIPTION
Previously, any class filter given to `traverse` wouldn't be respected
for the source node (returned if `include_source=True`). This patch
addresses this.

This is considered a bug fix as opposed to a breaking change because:
* Filtering by class was broken anyway in the last mistletoe release.
* It is unintuitive and likely unintended for the filter not to apply to
  the source node.