### PR TITLE
💡 implement link titles in the JIRARenderer (contrib)

### DIFF
--- a/contrib/jira_renderer.py
+++ b/contrib/jira_renderer.py
@@ -63,10 +63,15 @@ class JIRARenderer(BaseRenderer):
         return template.format(src=token.src)
 
     def render_link(self, token):
-        template = '[{inner}|{target}]'
-        target = escape_url(token.target)
+        template = '[{inner}|{target}{title}]'
         inner = self.render_inner(token)
-        return template.format(target=target, inner=inner)
+        target = escape_url(token.target)
+        if token.title:
+            title = '|{}'.format(token.title)
+        else:
+            title = ''
+
+        return template.format(inner=inner, target=target, title=title)
 
     def render_auto_link(self, token):
         template = '[{target}]'

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -102,6 +102,15 @@ class TestJIRARenderer(BaseRendererTest):
         expected = '[{body}|{url}]'.format(url=url, body=body)
         actual = self.renderer.render(token)
         self.assertEqual(expected, actual)
+
+    def test_render_link_with_title(self):
+        url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
+        body = self.genRandomString(80, True)
+        title = self.genRandomString(20, True)
+        token = next(iter(tokenize_inner('[{body}]({url} "{title}")'.format(url=url, body=body, title=title))))
+        expected = '[{body}|{url}|{title}]'.format(url=url, body=body, title=title)
+        actual = self.renderer.render(token)
+        self.assertEqual(expected, actual)
     
     def test_render_footnote_link(self):
         pass


### PR DESCRIPTION
Sample _Markdown_:
```md
Sample: [inner](https://target "title")
```

In _Linux_, test with:
```sh
mistletoe -r contrib.jira_renderer.JIRARenderer <(echo 'Sample: [inner](https://target "title")')
```

_Jira_ result, before this PR changes:
```
Sample: [inner|https://target]
```

_Jira_ result, after this PR changes:
```
Sample: [inner|https://target|title]
```