### PR TITLE
Markdown renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ main package:
 * HTML
 * LaTeX
 * AST (Abstract Syntax Tree; handy for debugging the parsing process)
+* Markdown (Can be used to reflow the text, or make other types of automated
+  changes to Markdown documents)
 
 Renderers for the following output formats can be found
 in the [contrib][contrib] package:
@@ -106,6 +108,17 @@ from mistletoe.latex_renderer import LaTeXRenderer
 
 with open('foo.md', 'r') as fin:
     rendered = mistletoe.markdown(fin, LaTeXRenderer)
+```
+
+To reflow the text in a Markdown document with a max line length of 20 characters:
+
+```python
+import mistletoe
+from mistletoe.markdown_renderer import MarkdownRenderer
+
+with open('dev-guide.md', 'r') as fin:
+    with MarkdownRenderer(max_line_length=20) as renderer:
+        print(renderer.render(mistletoe.Document(fin)))
 ```
 
 Finally, here's how you would manually specify extra tokens via a renderer.

--- a/dev-guide.md
+++ b/dev-guide.md
@@ -244,3 +244,59 @@ with open('foo.md', 'r') as fin:
 For more info, take a look at the `base_renderer` module in mistletoe.
 The docstrings might give you a more granular idea of customizing mistletoe
 to your needs.
+
+## Markdown to Markdown
+
+Suppose you have some Markdown that you want to process and then output
+as Markdown again. Thanks to the text-like nature of Markdown, it is often
+possible to do this with text search-and-replace tools... but not always. For
+example, if you want to replace a text fragment in the plain text, but not
+in the embedded code samples, then the search-and-replace approach won't work.
+
+In this case you can use mistletoe's `MarkdownRenderer`:
+1. Parse Markdown to an AST tree (usually held in a `Document` token).
+2. Make modifications to the AST tree.
+3. Render back to Markdown using `MarkdownRenderer.render()`.
+
+Here is an example of how you can make text replacements in selected parts
+of the AST:
+
+```python
+import mistletoe
+from mistletoe.block_token import BlockToken, Heading, Paragraph, SetextHeading
+from mistletoe.markdown_renderer import MarkdownRenderer
+from mistletoe.span_token import InlineCode, RawText, SpanToken
+
+def update_text(token: SpanToken):
+    """Update the text contents of a span token and its children.
+    `InlineCode` tokens are left unchanged."""
+    if isinstance(token, RawText):
+        token.content = token.content.replace("mistletoe", "The Amazing mistletoe")
+
+    if not isinstance(token, InlineCode) and hasattr(token, "children"):
+        for child in token.children:
+            update_text(child)
+
+def update_block(token: BlockToken):
+    """Update the text contents of paragraphs and headings within this block,
+    and recursively within its children."""
+    if isinstance(token, (Paragraph, SetextHeading, Heading)):
+        for child in token.children:
+            update_text(child)
+
+    for child in token.children:
+        if isinstance(child, BlockToken):
+            update_block(child)
+
+with open("README.md", "r") as fin:
+    with MarkdownRenderer() as renderer:
+        document = mistletoe.Document(fin)
+        update_block(document)
+        md = renderer.render(document)
+        print(md)
+```
+
+If you're making large changes, so that the formatting of the document is
+affected, then it can be useful to also have the text reflowed. This can
+be done by specifying a `max_line_length` parameter in the call to the
+`MarkdownRenderer` constructor.

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -376,14 +376,20 @@ class BlockCode(BlockToken):
     @classmethod
     def read(cls, lines):
         line_buffer = []
+        trailing_blanks = 0
         for line in lines:
             if line.strip() == '':
                 line_buffer.append(line.lstrip(' ') if len(line) < 5 else line[4:])
+                trailing_blanks = trailing_blanks + 1 if line == '\n' else 0
                 continue
             if not line.replace('\t', '    ', 1).startswith('    '):
                 lines.backstep()
                 break
             line_buffer.append(cls.strip(line))
+            trailing_blanks = 0
+        for _ in range(trailing_blanks):
+            line_buffer.pop()
+            lines.backstep()
         return line_buffer
 
     @staticmethod
@@ -1041,6 +1047,7 @@ class HTMLBlock(BlockToken):
                     break
             elif line.strip() == '':
                 line_buffer.pop()
+                lines.backstep()
                 break
         return line_buffer
 

--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -1,0 +1,544 @@
+"""
+Markdown renderer for mistletoe.
+"""
+
+import re
+from itertools import chain
+from typing import Iterable, Sequence
+
+from mistletoe import block_token, span_token, token
+from mistletoe.base_renderer import BaseRenderer
+
+
+class BlankLine(block_token.BlockToken):
+    """
+    Blank line token. Represents a single blank line.
+    This is a leaf block token without children.
+    """
+
+    pattern = re.compile(r"\s*\n$")
+
+    def __init__(self, _):
+        self.children = []
+
+    @classmethod
+    def start(cls, line):
+        return cls.pattern.match(line)
+
+    @classmethod
+    def read(cls, lines):
+        return [next(lines)]
+
+
+class LinkReferenceDefinition(span_token.SpanToken):
+    """
+    Link reference definition. ([label]: dest "title")
+
+    Not included in the parsing process, but called by `LinkReferenceDefinitionBlock`.
+
+    Attributes:
+        label (str): link label, used in link references.
+        dest (str): link target.
+        title (str): link title (default to empty).
+    """
+
+    repr_attributes = ("label", "dest", "title")
+
+    def __init__(self, match):
+        self.label, self.dest, self.title, self.dest_type, self.title_delimiter = match
+
+
+class LinkReferenceDefinitionBlock(block_token.Footnote):
+    """
+    A sequence of link reference definitions.
+    This is a container block token. Its children are link reference definition tokens.
+
+    This class inherits from `Footnote` and modifies the behavior of the constructor,
+    to keep the tokens in the AST.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj.__init__(*args, **kwargs)
+        return obj
+
+    def __init__(self, matches):
+        self.children = [LinkReferenceDefinition(match) for match in matches]
+
+
+class Fragment:
+    """
+    Markdown fragment. Used when rendering trees of span tokens into flat sequences.
+    May carry additional data in addition to the text.
+
+    Attributes:
+        text (str): markdown fragment.
+    """
+
+    def __init__(self, text: str, **extras):
+        self.text = text
+        self.__dict__.update(extras)
+
+
+class MarkdownRenderer(BaseRenderer):
+    """
+    Markdown renderer.
+
+    Designed to make as "clean" a roundtrip as possible, markdown -> parsing -> rendering -> markdown,
+    except for nonessential whitespace. Except when rendering with word wrapping enabled.
+
+    Includes `HTMLBlock` and `HTMLSpan` tokens in the parsing.
+    """
+
+    _whitespace = re.compile(r"\s+")
+
+    def __init__(self, *extras, max_line_length: int = None):
+        """
+        If `max_line_length` is specified, the document is word wrapped to the
+        specified line length when rendered. Otherwise the formatting from the
+        original (parsed) document is retained as much as possible.
+        """
+        block_token.remove_token(block_token.Footnote)
+        super().__init__(
+            *chain(
+                (
+                    block_token.HTMLBlock,
+                    span_token.HTMLSpan,
+                    BlankLine,
+                    LinkReferenceDefinitionBlock,
+                ),
+                extras,
+            )
+        )
+        self.render_map["SetextHeading"] = self.render_setext_heading
+        self.render_map["CodeFence"] = self.render_fenced_code_block
+        self.render_map[
+            "LinkReferenceDefinition"
+        ] = self.render_link_reference_definition
+        self.max_line_length = max_line_length
+
+    def render(self, token: token.Token) -> str:
+        """
+        Renders the tree of tokens rooted at the given token into markdown.
+        """
+        if isinstance(token, block_token.BlockToken):
+            lines = self.render_map[token.__class__.__name__](
+                token, max_line_length=self.max_line_length
+            )
+        else:
+            lines = self.span_to_lines([token], max_line_length=self.max_line_length)
+
+        return "".join(map(lambda line: line + "\n", lines))
+
+    # rendering of span/inline tokens.
+    # rendered into sequences of Fragments.
+
+    def render_raw_text(self, token) -> Iterable[Fragment]:
+        yield Fragment(token.content, wordwrap=True)
+
+    def render_strong(self, token: span_token.Strong) -> Iterable[Fragment]:
+        return self.embed_span(Fragment(token.delimiter * 2), token.children)
+
+    def render_emphasis(self, token: span_token.Emphasis) -> Iterable[Fragment]:
+        return self.embed_span(Fragment(token.delimiter), token.children)
+
+    def render_inline_code(self, token: span_token.InlineCode) -> Iterable[Fragment]:
+        return self.embed_span(
+            Fragment(token.delimiter + token.padding),
+            token.children,
+            Fragment(token.padding + token.delimiter)
+        )
+
+    def render_strikethrough(
+        self, token: span_token.Strikethrough
+    ) -> Iterable[Fragment]:
+        return self.embed_span(Fragment("~~"), token.children)
+
+    def render_image(self, token: span_token.Image) -> Iterable[Fragment]:
+        yield Fragment("!")
+        yield from self.render_link_or_image(token, token.src)
+
+    def render_link(self, token: span_token.Link) -> Iterable[Fragment]:
+        return self.render_link_or_image(token, token.target)
+
+    def render_link_or_image(
+        self, token: span_token.SpanToken, target: str
+    ) -> Iterable[Fragment]:
+        yield from self.embed_span(
+            Fragment("["),
+            token.children,
+            Fragment("]"),
+        )
+
+        if token.dest_type == "uri" or token.dest_type == "angle_uri":
+            # "[" description "](" dest_part [" " title] ")"
+            yield Fragment("(")
+            dest_part = "<" + target + ">" if token.dest_type == "angle_uri" else target
+            yield Fragment(dest_part)
+            if token.title:
+                yield from (
+                    Fragment(" ", wordwrap=True),
+                    Fragment(token.title_delimiter),
+                    Fragment(token.title, wordwrap=True),
+                    Fragment(
+                        ")" if token.title_delimiter == "(" else token.title_delimiter,
+                    ),
+                )
+            yield Fragment(")")
+        elif token.dest_type == "full":
+            # "[" description "][" label "]"
+            yield from (
+                Fragment("["),
+                Fragment(token.label, wordwrap=True),
+                Fragment("]"),
+            )
+        elif token.dest_type == "collapsed":
+            # "[" description "][]"
+            yield Fragment("[]")
+        else:
+            # "[" description "]"
+            pass
+
+    def render_auto_link(self, token: span_token.AutoLink) -> Iterable[Fragment]:
+        yield Fragment("<" + token.children[0].content + ">")
+
+    def render_escape_sequence(
+        self, token: span_token.EscapeSequence
+    ) -> Iterable[Fragment]:
+        yield Fragment("\\" + token.children[0].content)
+
+    def render_line_break(self, token: span_token.LineBreak) -> Iterable[Fragment]:
+        yield Fragment(
+            token.content + "\n", wordwrap=token.soft, hard_line_break=not token.soft
+        )
+
+    def render_html_span(self, token: span_token.HTMLSpan) -> Iterable[Fragment]:
+        yield Fragment(token.content)
+
+    def render_link_reference_definition(
+        self, token: LinkReferenceDefinition
+    ) -> Iterable[Fragment]:
+        yield from (
+            Fragment("["),
+            Fragment(token.label, wordwrap=True),
+            Fragment("]: ", wordwrap=True),
+            Fragment(
+                "<" + token.dest + ">"
+                if token.dest_type == "angle_uri"
+                else token.dest,
+            ),
+        )
+        if token.title:
+            yield from (
+                Fragment(" ", wordwrap=True),
+                Fragment(token.title_delimiter),
+                Fragment(token.title, wordwrap=True),
+                Fragment(
+                    ")" if token.title_delimiter == "(" else token.title_delimiter,
+                ),
+            )
+
+    # rendering of block tokens.
+    # rendered into sequences of lines (strings), to be joined by newlines.
+
+    def render_document(
+        self, token: block_token.Document, max_line_length: int
+    ) -> Iterable[str]:
+        return self.blocks_to_lines(token.children, max_line_length=max_line_length)
+
+    def render_heading(
+        self, token: block_token.Heading, max_line_length: int
+    ) -> Iterable[str]:
+        # note: no word wrapping, because atx headings always fit on a single line.
+        line = "#" * token.level
+        text = next(self.span_to_lines(token.children, max_line_length=None), "")
+        if text:
+            line += " " + text
+        if token.closing_sequence:
+            line += " " + token.closing_sequence
+        return [line]
+
+    def render_setext_heading(
+        self, token: block_token.SetextHeading, max_line_length: int
+    ) -> Iterable[str]:
+        yield from self.span_to_lines(token.children, max_line_length=max_line_length)
+        yield token.underline
+
+    def render_quote(
+        self, token: block_token.Quote, max_line_length: int
+    ) -> Iterable[str]:
+        max_child_line_length = max_line_length - 2 if max_line_length else None
+        lines = self.blocks_to_lines(
+            token.children, max_line_length=max_child_line_length
+        )
+        return self.prefix_lines(lines or [""], "> ")
+
+    def render_paragraph(
+        self, token: block_token.Paragraph, max_line_length: int
+    ) -> Iterable[str]:
+        return self.span_to_lines(token.children, max_line_length=max_line_length)
+
+    def render_block_code(
+        self, token: block_token.BlockCode, max_line_length: int
+    ) -> Iterable[str]:
+        lines = token.content[:-1].split("\n")
+        return self.prefix_lines(lines, "    ")
+
+    def render_fenced_code_block(
+        self, token: block_token.BlockCode, max_line_length: int
+    ) -> Iterable[str]:
+        indentation = " " * token.indentation
+        yield indentation + token.delimiter + token.info_string
+        yield from self.prefix_lines(
+            token.content[:-1].split("\n"), indentation
+        )
+        yield indentation + token.delimiter
+
+    def render_list(
+        self, token: block_token.List, max_line_length: int
+    ) -> Iterable[str]:
+        return self.blocks_to_lines(token.children, max_line_length=max_line_length)
+
+    def render_list_item(
+        self, token: block_token.ListItem, max_line_length: int
+    ) -> Iterable[str]:
+        indentation = len(token.leader) + 1
+        max_child_line_length = (
+            max_line_length - indentation if max_line_length else None
+        )
+        lines = self.blocks_to_lines(
+            token.children, max_line_length=max_child_line_length
+        )
+        return self.prefix_lines(
+            list(lines) or [""], token.leader + " ", " " * indentation
+        )
+
+    def render_table(
+        self, token: block_token.Table, max_line_length: int
+    ) -> Iterable[str]:
+        # note: column widths are not preserved; they are automatically adjusted to fit the contents.
+        content = [self.table_row_to_text(token.header), []]
+        content.extend(self.table_row_to_text(row) for row in token.children)
+        col_widths = self.calculate_table_column_widths(content)
+        content[1] = self.table_separator_line_to_text(col_widths, token.column_align)
+        return [
+            self.table_row_to_line(col_text, col_widths, token.column_align)
+            for col_text in content
+        ]
+
+    def render_thematic_break(
+        self, token: block_token.ThematicBreak, max_line_length: int
+    ) -> Iterable[str]:
+        return [token.line]
+
+    def render_html_block(
+        self, token: block_token.HTMLBlock, max_line_length: int
+    ) -> Iterable[str]:
+        return token.content.split("\n")
+
+    def render_link_reference_definition_block(
+        self, token: LinkReferenceDefinitionBlock, max_line_length: int
+    ) -> Iterable[str]:
+        # each link reference definition starts on a new line
+        for child in token.children:
+            yield from self.span_to_lines([child], max_line_length=max_line_length)
+
+    def render_blank_line(
+        self, token: BlankLine, max_line_length: int
+    ) -> Iterable[str]:
+        return [""]
+
+    # helper methods
+
+    def embed_span(
+        self,
+        leader: Fragment,
+        tokens: Iterable[span_token.SpanToken],
+        trailer: Fragment = None,
+    ) -> Iterable[Fragment]:
+        """
+        Makes fragments from `tokens` and embeds within a leader and a trailer.
+        The trailer defaults to the same as the leader.
+        """
+        yield leader
+        yield from self.make_fragments(tokens)
+        yield trailer or leader
+
+    def blocks_to_lines(
+        self, tokens: Iterable[block_token.BlockToken], max_line_length: int
+    ) -> Iterable[str]:
+        """
+        Renders a sequence of block tokens into a sequence of lines.
+        """
+        for token in tokens:
+            yield from self.render_map[token.__class__.__name__](
+                token, max_line_length=max_line_length
+            )
+
+    def span_to_lines(
+        self, tokens: Iterable[span_token.SpanToken], max_line_length: int
+    ) -> Iterable[str]:
+        """
+        Renders a sequence of span (inline) tokens into a sequence of lines.
+        """
+        fragments = self.make_fragments(tokens)
+        return self.fragments_to_lines(fragments, max_line_length=max_line_length)
+
+    def make_fragments(self, tokens: Iterable[span_token.SpanToken]
+    ) -> Iterable[Fragment]:
+        """
+        Renders a sequence of span (inline) tokens into a sequence of Fragments.
+        """
+        return chain.from_iterable(
+            [self.render_map[token.__class__.__name__](token) for token in tokens]
+        )
+
+    @classmethod
+    def fragments_to_lines(
+        cls, fragments: Iterable[Fragment], max_line_length: int = None
+    ) -> Iterable[str]:
+        """
+        Renders a sequence of Fragments into lines.
+        With word wrapping, if a `max_line_length` is given, or else following the
+        original text flow as closely as possible.
+        """
+        current_line = ""
+        if not max_line_length:
+            # plain rendering: merge all fragments and split on newlines
+            for fragment in fragments:
+                if "\n" in fragment.text:
+                    lines = fragment.text.split("\n")
+                    yield current_line + lines[0]
+                    for inner_line in lines[1:-2]:
+                        yield inner_line
+                    current_line = lines[-1]
+                else:
+                    current_line += fragment.text
+        else:
+            # render with word wrapping
+            for word in cls.make_words(fragments):
+                if word == "\n":
+                    # hard line break
+                    yield current_line
+                    current_line = ""
+                    continue
+
+                if not current_line:
+                    # first word on an empty line: accept and continue
+                    current_line = word
+                    continue
+
+                # try to fit the word on the current line.
+                # if it doesn't fit, flush the line and start on the next
+                test = current_line + " " + word
+                if len(test) <= max_line_length:
+                    current_line = test
+                else:
+                    yield current_line
+                    current_line = word
+
+        if current_line:
+            yield current_line
+
+    @classmethod
+    def make_words(cls, fragments: Iterable[Fragment]) -> Iterable[str]:
+        """
+        Aggregates and splits a sequence of Fragments into words, i.e., strings
+        which do not contain breakable spaces or line breaks. The exception is
+        hard line breaks, which are represented by the string `\n`.
+        """
+        word = ""
+        for fragment in fragments:
+            if getattr(fragment, "wordwrap", False):
+                first = True
+                for item in cls._whitespace.split(fragment.text):
+                    if first:
+                        word += item
+                        first = False
+                    else:
+                        if word:
+                            yield word
+                        word = item
+            elif getattr(fragment, "hard_line_break", False):
+                yield from (word + fragment.text[:-1], "\n")
+                word = ""
+            else:
+                word += fragment.text
+
+        if word:
+            yield word
+
+    @classmethod
+    def prefix_lines(
+        cls,
+        lines: Iterable[str],
+        first_line_prefix: str,
+        following_line_prefix: str = None,
+    ) -> Iterable[str]:
+        """
+        Prepends a prefix string to a sequence of lines. The first line may
+        have a different prefix from the following lines.
+        """
+        following_line_prefix = following_line_prefix or first_line_prefix
+        is_first_line = True
+        for line in lines:
+            if is_first_line:
+                prefixed = first_line_prefix + line
+                is_first_line = False
+            else:
+                prefixed = following_line_prefix + line
+            yield prefixed if not prefixed.isspace() else ""
+
+    def table_row_to_text(self, row) -> Sequence[str]:
+        """
+        Renders each table cell on a table row to text. No word wrapping.
+        """
+        return [next(self.span_to_lines(col.children, max_line_length=None), "") for col in row.children]
+
+    @classmethod
+    def calculate_table_column_widths(cls, col_text) -> Sequence[int]:
+        """
+        Calculates column widths for a table.
+        """
+        MINIMUM_COLUMN_WIDTH = 3
+        col_widths = []
+        for row in col_text:
+            while len(col_widths) < len(row):
+                col_widths.append(MINIMUM_COLUMN_WIDTH)
+            for index, text in enumerate(row):
+                col_widths[index] = max(col_widths[index], len(text))
+        return col_widths
+
+    @classmethod
+    def table_separator_line_to_text(cls, col_widths, col_align) -> Sequence[str]:
+        """
+        Creates the text for the line separating header from contents in a table
+        given column widths and alignments.
+
+        Note: uses dashes for left justified columns, not a colon followed by dashes.
+        """
+        separator_text = []
+        for index, width in enumerate(col_widths):
+            align = col_align[index] if index < len(col_align) else None
+            sep = ":" if align == 0 else "-"
+            sep += "-" * (width - 2)
+            sep += ":" if align == 0 or align == 1 else "-"
+            separator_text.append(sep)
+        return separator_text
+
+    @classmethod
+    def table_row_to_line(cls, col_text, col_widths, col_align) -> str:
+        """
+        Pads/aligns the text for a table row and add the borders (pipe characters).
+        """
+        padded_text = []
+        for index, width in enumerate(col_widths):
+            text = col_text[index] if index < len(col_text) else ""
+            align = col_align[index] if index < len(col_align) else None
+            if align is None:
+                padded_text.append("{0: <{w}}".format(text, w=width))
+            elif align == 0:
+                padded_text.append("{0: ^{w}}".format(text, w=width))
+            else:
+                padded_text.append("{0: >{w}}".format(text, w=width))
+        return "".join(("| ", " | ".join(padded_text), " |"))

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -125,6 +125,11 @@ class TestBlockCode(TestToken):
         arg = 'rm dir\nmkdir test\n'
         self._test_match(block_token.BlockCode, lines, arg, language='')
 
+    def test_parse_indented_code_with_blank_lines(self):
+        lines = ['    chunk1\n', '\n', '    chunk2\n', '  \n', ' \n', ' \n', '    chunk3\n']
+        arg = 'chunk1\n\nchunk2\n\n\n\nchunk3\n'
+        self._test_match(block_token.BlockCode, lines, arg, language='')
+
 
 class TestParagraph(TestToken):
     def test_parse(self):

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -1,0 +1,539 @@
+import unittest
+
+from mistletoe import block_token, span_token
+from mistletoe.block_token import Document
+from mistletoe.markdown_renderer import MarkdownRenderer
+
+
+class TestMarkdownRenderer(unittest.TestCase):
+    @staticmethod
+    def roundtrip(input):
+        """Parses the given markdown input and renders it back to markdown again."""
+        with MarkdownRenderer() as renderer:
+            return renderer.render(Document(input))
+
+    def test_empty_document(self):
+        input = []
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_paragraphs_and_blank_lines(self):
+        input = [
+            "Paragraph 1. Single line. Followed by two white-space-only lines.\n",
+            "\n",
+            "\n",
+            "Paragraph 2. Two\n",
+            "lines, no final line break.",
+        ]
+        rendered = self.roundtrip(input)
+        # note: a line break is always added at the end of a paragraph.
+        self.assertEqual(rendered, "".join(input) + "\n")
+
+    def test_line_breaks(self):
+        input = [
+            "soft line break\n",
+            "hard line break (backslash)\\\n",
+            "another hard line break (double spaces)  \n",
+            "yet another hard line break    \n",
+            "that's all.\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_emphasized_and_strong(self):
+        input = ["*emphasized* __strong__ _**emphasized and strong**_\n"]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_strikethrough(self):
+        input = ["~~strikethrough~~\n"]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_escaped_chars(self):
+        input = ["\\*escaped, not emphasized\\*\n"]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_html_span(self):
+        input = ["so <p>hear ye</p><h1>\n"]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_code_span(self):
+        input = [
+            "a) `code span` b) ``trailing space, double apostrophes `` c) ` leading and trailing space `\n"
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_code_span_with_embedded_line_breaks(self):
+        input = [
+            "a `multi-line\n",
+            "code\n",
+            "span`.\n"
+        ]
+        expected = [
+            "a `multi-line code span`.\n"
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(expected))
+
+    def test_images_and_links(self):
+        input = [
+            "[a link](#url (title))\n",
+            "[another link](<url-in-angle-brackets> '*emphasized\n",
+            "title*')\n",
+            '![an \\[*image*\\], escapes and emphasis](#url "title")\n',
+            "<http://auto.link>\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_thematic_break(self):
+        input = [
+            " **  * ** * ** * **\n",
+            "followed by a paragraph of text\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_atx_headings(self):
+        input = [
+            "## atx *heading* ##\n",
+            "# another atx heading, without trailing hashes\n",
+            "###\n",
+            "^ empty atx heading\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_setext_headings(self):
+        input = [
+            "*setext*\n",
+            "heading!\n",
+            "===============\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_numbered_list(self):
+        input = [
+            "  22)  *emphasized list item*\n",
+            "  96)\n",
+            " 128) here begins a nested list.\n",
+            "       + apples\n",
+            "       +  bananas\n",
+        ]
+        expected = [
+            "22) *emphasized list item*\n",
+            "96) \n",
+            "128) here begins a nested list.\n",
+            "     + apples\n",
+            "     + bananas\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(expected))
+
+    def test_bulleted_list(self):
+        input = [
+            "* **test case**:\n",
+            "  testing a link as the first item on a continuation line\n",
+            "  [links must be indented][properly].\n",
+            "\n",
+            "[properly]: uri\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_code_blocks(self):
+        input = [
+            "    this is an indented code block\n",
+            "      on two lines \n",
+            "    with some extra whitespace here and there, to be preserved  \n",
+            "      just as it is.\n",
+            "```\n",
+            "now for a fenced code block \n",
+            "  where indentation is also preserved. as are the double spaces at the end of this line:  \n",
+            "```\n",
+            "  ~~~this is an info string: behold the fenced code block with tildes!\n",
+            "  *tildes are great*\n",
+            "  ~~~\n",
+            "1. a list item with an embedded\n",
+            "\n",
+            "       indented code block.\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_blank_lines_following_code_block(self):
+        input = [
+            "    code block\n",
+            "\n",
+            "paragraph.\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_html_block(self):
+        input = [
+            "<h1>some text <img src='https://cdn.rawgit.com/' align='right'></h1>\n",
+            "<br>\n",
+            "\n",
+            "+ <h1>html block embedded in list <img src='https://cdn.rawgit.com/' align='right'></h1>\n",
+            "  <br>\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_block_quote(self):
+        input = [
+            "> a block quote\n",
+            "> > and a nested block quote\n",
+            "> 1. > and finally, a list with a nested block quote\n",
+            ">    > which continues on a second line.\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_link_reference_definition(self):
+        input = [
+            "[label]: https://domain.com\n",
+            "\n",
+            "paragraph [with a link][label-2], etc, etc.\n",
+            "and [a *second* link][label] as well\n",
+            "shortcut [label] & collapsed [label][]\n",
+            "\n",
+            "[label-2]: <https://libraries.io/> 'title\n",
+            "with line break'\n",
+            "[label-not-referred-to]: https://foo (title)\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_table(self):
+        input = [
+            "| Emoji | Description               |\n",
+            "| :---: | ------------------------- |\n",
+            "|   📚   | Update documentation.     |\n",
+            "|   🐎   | Performance improvements. |\n",
+            "etc, etc\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(input))
+
+    def test_table_with_varying_column_counts(self):
+        input = [
+            "   |   header | x |  \n",
+            "   | --- | ---: |   \n",
+            "   | . | Performance improvements. | an extra column |   \n",
+            "etc, etc\n",
+        ]
+        expected = [
+            "| header |                         x |                 |\n",
+            "| ------ | ------------------------: | --------------- |\n",
+            "| .      | Performance improvements. | an extra column |\n",
+            "etc, etc\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(expected))
+
+    def test_table_with_narrow_column(self):
+        input = [
+            "| xyz | ? |\n",
+            "| --- | - |\n",
+            "| a   | p |\n",
+            "| b   | q |\n",
+        ]
+        expected = [
+            "| xyz | ?   |\n",
+            "| --- | --- |\n",
+            "| a   | p   |\n",
+            "| b   | q   |\n",
+        ]
+        rendered = self.roundtrip(input)
+        self.assertEqual(rendered, "".join(expected))
+
+    def test_direct_rendering_of_block_token(self):
+        input = [
+            "Line 1\n",
+            "Line 2\n",
+        ]
+        paragraph = block_token.Paragraph(input)
+        with MarkdownRenderer() as renderer:
+            lines = renderer.render(paragraph)
+        assert lines == "".join(input)
+
+    def test_direct_rendering_of_span_token(self):
+        input = "some text"
+        raw_text = span_token.RawText(input)
+        with MarkdownRenderer() as renderer:
+            lines = renderer.render(raw_text)
+        assert lines == input + "\n"
+
+
+class TestMarkdownFormatting(unittest.TestCase):
+    def test_wordwrap_plain_paragraph(self):
+        with MarkdownRenderer() as renderer:
+            # given a paragraph with only plain text and soft line breaks
+            paragraph = block_token.Paragraph(
+                [
+                    "A \n",
+                    "short   paragraph \n",
+                    "   without any \n",
+                    "long words \n",
+                    "or hard line breaks.\n",
+                ]
+            )
+
+            # when reflowing with the max line length set medium long
+            renderer.max_line_length = 30
+            lines = renderer.render(paragraph)
+
+            # then the content is reflowed accordingly
+            assert lines == (
+                "A short paragraph without any\n"
+                "long words or hard line\n"
+                "breaks.\n"
+            )
+
+            # when reflowing with the max line length set lower than the longest word: "paragraph", 9 chars
+            renderer.max_line_length = 8
+            lines = renderer.render(paragraph)
+
+            # then the content is reflowed so that the max line length is only exceeded for long words
+            assert lines == (
+                "A short\n"
+                "paragraph\n"
+                "without\n"
+                "any long\n"
+                "words or\n"
+                "hard\n"
+                "line\n"
+                "breaks.\n"
+            )
+
+    def test_wordwrap_paragraph_with_emphasized_words(self):
+        with MarkdownRenderer() as renderer:
+            # given a paragraph with emphasized words
+            paragraph = block_token.Paragraph(
+                ["*emphasized* _nested *emphasis* too_\n"]
+            )
+
+            # when reflowing with the max line length set very short
+            renderer.max_line_length = 1
+            lines = renderer.render(paragraph)
+
+            # then the content is reflowed to make the lines as short as possible (but not shorter).
+            assert lines == (
+                "*emphasized*\n"
+                "_nested\n"
+                "*emphasis*\n"
+                "too_\n"
+            )
+
+    def test_wordwrap_paragraph_with_inline_code(self):
+        with MarkdownRenderer() as renderer:
+            # given a paragraph with inline code
+            paragraph = block_token.Paragraph(
+                [
+                    "`inline code` and\n",
+                    "`` inline with\n",
+                    "line break ``\n",
+                ]
+            )
+
+            # when reflowing with the max line length set very short
+            renderer.max_line_length = 1
+            lines = renderer.render(paragraph)
+
+            # then the content is reflowed to make the lines as short as possible (but not shorter).
+            # line breaks within the inline code are NOT preserved.
+            # however, padding at the end of the inline code may not be word wrapped.
+            assert lines == (
+                "`inline\n"
+                "code`\n"
+                "and\n"
+                "`` inline\n"
+                "with\n"
+                "line\n"
+                "break ``\n"
+            )
+
+    def test_wordwrap_paragraph_with_hard_line_breaks(self):
+        with MarkdownRenderer() as renderer:
+            # given a paragraph with hard line breaks
+            paragraph = block_token.Paragraph(
+                [
+                    "A short paragraph  \n",
+                    "  without any\\\n",
+                    "very long\n",
+                    "words.\n",
+                ]
+            )
+
+            # when reflowing with the max line length set to normal
+            renderer.max_line_length = 80
+            lines = renderer.render(paragraph)
+
+            # then the content is reflowed with hard line breaks preserved
+            assert lines == (
+                "A short paragraph  \n"
+                "without any\\\n"
+                "very long words.\n"
+            )
+
+    def test_wordwrap_paragraph_with_link(self):
+        with MarkdownRenderer() as renderer:
+            # given a paragraph with a link
+            paragraph = block_token.Paragraph(
+                [
+                    "A paragraph\n",
+                    "containing [a link](<link destination with non-breaking spaces> 'which\n",
+                    "has a rather long title\n",
+                    "spanning multiple lines.')\n",
+                ]
+            )
+
+            # when reflowing with the max line length set very short
+            renderer.max_line_length = 1
+            lines = renderer.render(paragraph)
+
+            # then the content is reflowed to make the lines as short as possible (but not shorter)
+            assert lines == (
+                "A\n"
+                "paragraph\n"
+                "containing\n"
+                "[a\n"
+                "link](<link destination with non-breaking spaces>\n"
+                "'which\n"
+                "has\n"
+                "a\n"
+                "rather\n"
+                "long\n"
+                "title\n"
+                "spanning\n"
+                "multiple\n"
+                "lines.')\n"
+            )
+
+    def test_wordwrap_text_in_setext_heading(self):
+        with MarkdownRenderer() as renderer:
+            # given a paragraph with a setext heading
+            document = block_token.Document(
+                [
+                    "A \n",
+                    "setext   heading \n",
+                    "   without any \n",
+                    "long words \n",
+                    "or hard line breaks.\n",
+                    "=====\n",
+                ]
+            )
+
+            # when reflowing with the max line length set medium long
+            renderer.max_line_length = 30
+            lines = renderer.render(document)
+
+            # then the content is reflowed accordingly
+            assert lines == (
+                "A setext heading without any\n"
+                "long words or hard line\n"
+                "breaks.\n"
+                "=====\n"
+            )
+
+    def test_wordwrap_text_in_link_reference_definition(self):
+        with MarkdownRenderer() as renderer:
+            # given some markdown with link reference definitions
+            document = block_token.Document(
+                [
+                    "[This is\n",
+                    "  the *link label*.]:<a long, non-breakable link reference> 'title (with parens). new\n",
+                    "lines allowed.'\n",
+                    "[*]:url  'Another   link      reference\tdefinition'\n",
+                ]
+            )
+
+            # when reflowing with the max line length set medium long
+            renderer.max_line_length = 30
+            lines = renderer.render(document)
+
+            # then the content is reflowed accordingly
+            assert lines == (
+                "[This is the *link label*.]:\n"
+                "<a long, non-breakable link reference>\n"
+                "'title (with parens). new\n"
+                "lines allowed.'\n"
+                "[*]: url 'Another link\n"
+                "reference definition'\n"
+            )
+
+    def test_wordwrap_paragraph_in_list(self):
+        with MarkdownRenderer() as renderer:
+            # given some markdown with a nested list
+            document = block_token.Document(
+                [
+                    "1. List item\n",
+                    "2. A second list item including:\n",
+                    "   * Nested list.\n",
+                    "     This is a continuation line\n",
+                ]
+            )
+
+            # when reflowing with the max line length set medium long
+            renderer.max_line_length = 25
+            lines = renderer.render(document)
+
+            # then the content is reflowed accordingly
+            assert lines == (
+                "1. List item\n"
+                "2. A second list item\n"
+                "   including:\n"
+                "   * Nested list. This is\n"
+                "     a continuation line\n"
+            )
+
+    def test_wordwrap_paragraph_in_block_quote(self):
+        with MarkdownRenderer() as renderer:
+            # given some markdown with nested block quotes
+            document = block_token.Document(
+                [
+                    "> Devouring Time, blunt thou the lion's paws,\n",
+                    "> And make the earth devour her own sweet brood;\n",
+                    "> > When Dawn strides out to wake a dewy farm\n",
+                    "> > Across green fields and yellow hills of hay\n",
+                ]
+            )
+
+            # when reflowing with the max line length set medium long
+            renderer.max_line_length = 30
+            lines = renderer.render(document)
+
+            # then the content is reflowed accordingly
+            assert lines == (
+                "> Devouring Time, blunt thou\n"
+                "> the lion's paws, And make\n"
+                "> the earth devour her own\n"
+                "> sweet brood;\n"
+                "> > When Dawn strides out to\n"
+                "> > wake a dewy farm Across\n"
+                "> > green fields and yellow\n"
+                "> > hills of hay\n"
+            )
+
+    def test_wordwrap_tables(self):
+        with MarkdownRenderer(max_line_length=30) as renderer:
+            # given a markdown table
+            input = [
+                "| header |                         x |                 |\n",
+                "| ------ | ------------------------: | --------------- |\n",
+                "| .      | Performance improvements. | an extra column |\n",
+            ]
+            document = block_token.Document(input)
+
+            # when reflowing
+            lines = renderer.render(document)
+
+            # then the table is rendered without any word wrapping
+            assert lines == "".join(input)

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -113,7 +113,7 @@ class TestRepr(unittest.TestCase):
 
     def test_hard_linebreak(self):
         doc = Document("Foo\\\nBar\n")
-        self._check_repr_matches(doc.children[0].children[1], "span_token.LineBreak content='' soft=False")
+        self._check_repr_matches(doc.children[0].children[1], "span_token.LineBreak content='\\\\' soft=False")
 
     def test_rawtext(self):
         doc = Document("Foo\n")

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -165,9 +165,20 @@ class TestRawText(unittest.TestCase):
 
 
 class TestLineBreak(unittest.TestCase):
-    def test_parse(self):
+    def test_parse_soft_break(self):
+        token, = span_token.tokenize_inner('\n')
+        self.assertIsInstance(token, span_token.LineBreak)
+        self.assertTrue(token.soft)
+
+    def test_parse_hard_break_with_double_blanks(self):
         token, = span_token.tokenize_inner('  \n')
         self.assertIsInstance(token, span_token.LineBreak)
+        self.assertFalse(token.soft)
+
+    def test_parse_hard_break_with_backslash(self):
+        _, token, = span_token.tokenize_inner(' \\\n')
+        self.assertIsInstance(token, span_token.LineBreak)
+        self.assertFalse(token.soft)
 
 
 class TestContains(unittest.TestCase):


### PR DESCRIPTION
This is a pull request for a Markdown-to-Markdown renderer (#4).

A few notes on the implementation:

1. Since the aim is to preserve as much of the formatting as possible, and also steer clear of issues like if
   the sequence `_**Hello**_` would be rendered as `***Hello***` (which changes its interpretation),
   I had to save some formatting information from the parsing in the tokens. The formatting info will not appear in the output from the ASTRenderer or from repr().

2. The Markdown renderer can also do word wrapping. (Because I needed that for a use case.) But that's optional, and when it's not enabled, the goal is still to make the roundtrip Markdown -> parse -> render -> Markdown with as few changes as possible.

3. The test cases in `TestMarkdownRenderer` give a pretty good idea of what the renderer is capable of.
   In particular, note that it handles nested blocks: you can put a code block inside a list inside a block quote 
   if you like. (This is explicitly allowed by the CommonMark spec.)

4. Three new tokens! Well actually, only one which is completely new and that's the `BlankLine`.
   The other two represent link reference definitions (a.k.a. footnotes) and inherit from the`Footnote` token.
   These tokens are used to represent content that is otherwise not included in the AST.

   An open question is whether they belong in the same module as the markdown renderer class, or if they should
   be moved somewhere else. Maybe create a new module to host all optional tokens?

5. The markdown renderer handles span tokens and block tokens differently.
   Block tokens are rendered into chunks of lines.
   Span tokens are first rendered into sequences of "fragments", which are essentially strings with some additional metadata attached, and then into chunks of lines.

6. Tables are supported.

7. I put the MarkdownRenderer in the main package, not in contrib, because that's what @miyuchina wrote in a comment on #4.

Hope this can be useful and looking forward to some review comments. As it's a fairly large PR, I'd recommend to review it commit by commit. All changes to existing code come first, and then finally the renderer itself.