### PR TITLE
Modified the HTMLBlock token as described in #163, Inconsistencies in the block tokens

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -361,7 +361,7 @@ class BlockCode(BlockToken):
 
     @property
     def content(self):
-        """Return the code block content."""
+        """Returns the code block content."""
         return self.children[0].content
 
     @staticmethod
@@ -415,7 +415,7 @@ class CodeFence(BlockToken):
 
     @property
     def content(self):
-        """Return the code block content."""
+        """Returns the code block content."""
         return self.children[0].content
 
     @classmethod
@@ -972,7 +972,7 @@ class HTMLBlock(BlockToken):
 
     @property
     def content(self):
-        """Return the raw HTML content."""
+        """Returns the raw HTML content."""
         return self.children[0].content
 
     @classmethod

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -946,10 +946,10 @@ class ThematicBreak(BlockToken):
 class HTMLBlock(BlockToken):
     """
     Block-level HTML token.
-    This is a leaf block token without children.
+    This is a leaf block token with a single child of type span_token.RawText.
 
     Attributes:
-        content (str): the raw HTML content.
+        children (list): contains a single span_token.RawText token with the raw HTML content.
     """
     _end_cond = None
     multiblock = re.compile(r'<(pre|script|style|textarea)[ >\n]')
@@ -958,7 +958,12 @@ class HTMLBlock(BlockToken):
                                 span_token._closing_tag)) + r')\s*$')
 
     def __init__(self, lines):
-        self.content = ''.join(lines).rstrip('\n')
+        self.children = (span_token.RawText(''.join(lines).rstrip('\n')),)
+
+    @property
+    def content(self):
+        """Return the raw HTML content."""
+        return self.children[0].content
 
     @classmethod
     def start(cls, line):

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -359,6 +359,11 @@ class BlockCode(BlockToken):
         self.language = ''
         self.children = (span_token.RawText(''.join(lines).strip('\n')+'\n'),)
 
+    @property
+    def content(self):
+        """Return the code block content."""
+        return self.children[0].content
+
     @staticmethod
     def start(line):
         return line.replace('\t', '    ', 1).startswith('    ')
@@ -407,6 +412,11 @@ class CodeFence(BlockToken):
         lines, open_info = match
         self.language = span_token.EscapeSequence.strip(open_info[2])
         self.children = (span_token.RawText(''.join(lines)),)
+
+    @property
+    def content(self):
+        """Return the code block content."""
+        return self.children[0].content
 
     @classmethod
     def start(cls, line):

--- a/mistletoe/contrib/pygments_renderer.py
+++ b/mistletoe/contrib/pygments_renderer.py
@@ -14,7 +14,7 @@ class PygmentsRenderer(HTMLRenderer):
 
 
     def render_block_code(self, token):
-        code = token.children[0].content
+        code = token.content
         lexer = get_lexer(token.language) if token.language else guess_lexer(code)
         return highlight(code, lexer, self.formatter)
 

--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -113,7 +113,7 @@ class HTMLRenderer(BaseRenderer):
             attr = ' class="{}"'.format('language-{}'.format(html.escape(token.language)))
         else:
             attr = ''
-        inner = html.escape(token.children[0].content)
+        inner = html.escape(token.content)
         return template.format(attr=attr, inner=inner)
 
     def render_list(self, token: block_token.List) -> str:

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -119,45 +119,11 @@ class TestCodeFence(TestToken):
         self._test_match(block_token.CodeFence, lines, arg, language='aa')
 
 
-class TestCodeFenceBehavior(unittest.TestCase):
-    def test_content_property(self):
-        lines = ['```\n',
-                 'line 1\n',
-                 'line 2\n',
-                 '```\n']
-        document = block_token.Document(lines)
-        tokens = document.children
-        self.assertEqual(1, len(tokens))
-        self.assertIsInstance(tokens[0], block_token.CodeFence)
-
-        # option 1: direct access to the content
-        self.assertEqual('line 1\nline 2\n', tokens[0].children[0].content)
-
-        # option 2: using property getter to access the content
-        self.assertEqual('line 1\nline 2\n', tokens[0].content)
-
-
 class TestBlockCode(TestToken):
     def test_parse_indented_code(self):
         lines = ['    rm dir\n', '    mkdir test\n']
         arg = 'rm dir\nmkdir test\n'
         self._test_match(block_token.BlockCode, lines, arg, language='')
-
-
-class TestBlockCodeBehavior(unittest.TestCase):
-    def test_content_property(self):
-        lines = ['    line 1\n',
-                 '    line 2\n']
-        document = block_token.Document(lines)
-        tokens = document.children
-        self.assertEqual(1, len(tokens))
-        self.assertIsInstance(tokens[0], block_token.BlockCode)
-
-        # option 1: direct access to the content
-        self.assertEqual('line 1\nline 2\n', tokens[0].children[0].content)
-
-        # option 2: using property getter to access the content
-        self.assertEqual('line 1\nline 2\n', tokens[0].content)
 
 
 class TestParagraph(TestToken):
@@ -583,7 +549,43 @@ class TestHTMLBlock(unittest.TestCase):
         self.assertEqual(1, len(tokens))
         self.assertIsInstance(tokens[0], block_token.HTMLBlock)
 
-    def test_content_property(self):
+
+class TestLeafBlockTokenContentProperty(unittest.TestCase):
+    def setUp(self):
+        block_token.add_token(block_token.HTMLBlock)
+        self.addCleanup(block_token.reset_tokens)
+
+    def test_code_fence(self):
+        lines = ['```\n',
+                 'line 1\n',
+                 'line 2\n',
+                 '```\n']
+        document = block_token.Document(lines)
+        tokens = document.children
+        self.assertEqual(1, len(tokens))
+        self.assertIsInstance(tokens[0], block_token.CodeFence)
+
+        # option 1: direct access to the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].children[0].content)
+
+        # option 2: using property getter to access the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].content)
+
+    def test_block_code(self):
+        lines = ['    line 1\n',
+                 '    line 2\n']
+        document = block_token.Document(lines)
+        tokens = document.children
+        self.assertEqual(1, len(tokens))
+        self.assertIsInstance(tokens[0], block_token.BlockCode)
+
+        # option 1: direct access to the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].children[0].content)
+
+        # option 2: using property getter to access the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].content)
+
+    def test_html_block(self):
         lines = ['<div>\n',
                  'text\n'
                  '</div>\n']

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -548,3 +548,18 @@ class TestHTMLBlock(unittest.TestCase):
         tokens = document.children
         self.assertEqual(1, len(tokens))
         self.assertIsInstance(tokens[0], block_token.HTMLBlock)
+
+    def test_content_property(self):
+        lines = ['<div>\n',
+                 'text\n'
+                 '</div>\n']
+        document = block_token.Document(lines)
+        tokens = document.children
+        self.assertEqual(1, len(tokens))
+        self.assertIsInstance(tokens[0], block_token.HTMLBlock)
+
+        # option 1: direct access to the content
+        self.assertEqual(''.join(lines).strip(), tokens[0].children[0].content)
+
+        # option 2: using property getter to access the content
+        self.assertEqual(''.join(lines).strip(), tokens[0].content)

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -119,11 +119,45 @@ class TestCodeFence(TestToken):
         self._test_match(block_token.CodeFence, lines, arg, language='aa')
 
 
+class TestCodeFenceBehavior(unittest.TestCase):
+    def test_content_property(self):
+        lines = ['```\n',
+                 'line 1\n',
+                 'line 2\n',
+                 '```\n']
+        document = block_token.Document(lines)
+        tokens = document.children
+        self.assertEqual(1, len(tokens))
+        self.assertIsInstance(tokens[0], block_token.CodeFence)
+
+        # option 1: direct access to the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].children[0].content)
+
+        # option 2: using property getter to access the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].content)
+
+
 class TestBlockCode(TestToken):
     def test_parse_indented_code(self):
         lines = ['    rm dir\n', '    mkdir test\n']
         arg = 'rm dir\nmkdir test\n'
         self._test_match(block_token.BlockCode, lines, arg, language='')
+
+
+class TestBlockCodeBehavior(unittest.TestCase):
+    def test_content_property(self):
+        lines = ['    line 1\n',
+                 '    line 2\n']
+        document = block_token.Document(lines)
+        tokens = document.children
+        self.assertEqual(1, len(tokens))
+        self.assertIsInstance(tokens[0], block_token.BlockCode)
+
+        # option 1: direct access to the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].children[0].content)
+
+        # option 2: using property getter to access the content
+        self.assertEqual('line 1\nline 2\n', tokens[0].content)
 
 
 class TestParagraph(TestToken):

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -65,8 +65,13 @@ class TestRepr(unittest.TestCase):
     # No test for ``Footnote``
 
     def test_htmlblock(self):
-        token = block_token.HTMLBlock("<pre>\nFoo\n</pre>\n")
-        self._check_repr_matches(token, "block_token.HTMLBlock content='<pre>\\nFoo\\n</pre>'")
+        try:
+            block_token.add_token(block_token.HTMLBlock)
+            doc = Document("<pre>\nFoo\n</pre>\n")
+        finally:
+            block_token.reset_tokens()
+        self._check_repr_matches(doc.children[0], "block_token.HTMLBlock with 1 child")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.RawText content='<pre>\\nFoo\\n</pre>'")
 
     # Span tokens
 


### PR DESCRIPTION
Modified the HTMLBlock to store its content in a RawText child node, like all the other block tokens, instead of a content attribute.  This makes it easier to iterate over the token tree, because all block tokens can be handled the same way.

Added a convenience wrapper to preserve backward compatibility.