### PR TITLE
Include any custom HTML attributes on any Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,36 @@ without touching any of the core components.
 
 Remember to spell mistletoe in lowercase!
 
+In This Fork
+------------
+
+**Html attribute block Proposed Spec**
+Prepend line containing `{...}` will describe the html attributes that will be added during the tokenizer process.
+Contents within the Html attribute block will be a comma separated list of key/value pairs. 
+Any key prefixed with `>` will apply to the children token.
+
+
+**Example Html attribute block**
+INPUT
+```
+{id:my-value, class:some-class}
+# Mistletoe is Awesome
+
+{id:my-list, class:foo, >class:bar-items}
+- Item One
+- Item Two
+- Item Three\
+```
+OUTPUT
+```
+<h1 id="my-value" class="some-class">Mistletoe is Awesome</h1>
+<ul id="my-list" class="foo">
+    <li class="bar-items">Item One</li>
+    <li class="bar-items">Item Two</li>
+    <li class="bar-items">Item Three</li>
+</ul>
+```
+
 Features
 --------
 * **Fast**:

--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -99,9 +99,11 @@ class HTMLRenderer(BaseRenderer):
         return token.content
 
     def render_heading(self, token: block_token.Heading) -> str:
-        template = '<h{level}>{inner}</h{level}>'
+        template = '<h{level}{attr}>{inner}</h{level}>'
         inner = self.render_inner(token)
-        return template.format(level=token.level, inner=inner)
+        id = inner.replace(' ','-').lower()
+        attr = f' id="{id}"' if not token.html_props else token.html_props
+        return template.format(level=token.level, attr=html.unescape(attr), inner=inner)
 
     def render_quote(self, token: block_token.Quote) -> str:
         elements = ['<blockquote>']
@@ -132,7 +134,7 @@ class HTMLRenderer(BaseRenderer):
             attr = ' start="{}"'.format(token.start) if token.start != 1 else ''
         else:
             tag = 'ul'
-            attr = ''
+            attr = '' if not token.html_props else token.html_props
         self._suppress_ptag_stack.append(not token.loose)
         inner = '\n'.join([self.render(child) for child in token.children])
         self._suppress_ptag_stack.pop()
@@ -148,7 +150,8 @@ class HTMLRenderer(BaseRenderer):
                 inner_template = inner_template[1:]
             if token.children[-1].__class__.__name__ == 'Paragraph':
                 inner_template = inner_template[:-1]
-        return '<li>{}</li>'.format(inner_template.format(inner))
+        attr = '' if not token.html_props else token.html_props
+        return '<li{attr}>{}</li>'.format(inner_template.format(inner), attr=attr)
 
     def render_table(self, token: block_token.Table) -> str:
         # This is actually gross and I wonder if there's a better way to do it.

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -39,7 +39,7 @@ class Token:
     """
 
     repr_attributes = ()
-
+    html_props = None
     def __repr__(self):
         output = "<{}.{}".format(
             self.__class__.__module__,


### PR DESCRIPTION
This is similar to this [PR#134](https://github.com/miyuchina/mistletoe/pull/134)

I would like to propose an alternative solution that will not alter existing `render` methods.

**Html attribute block Proposed Spec**
Prepend line containing `{...}` will describe the html attributes that will be added during the tokenizer process.
Contents within the Html attribute block will be a comma separated list of key/value pairs. 
Any key prefixed with `>` will apply to the children token.


**Example Html attribute block**
INPUT
```
{id:my-value, class:some-class}
# Mistletoe is Awesome

{id:my-list, class:foo, >class:bar-items}
- Item One
- Item Two
- Item Three\
```
OUTPUT
```
<h1 id="my-value" class="some-class">Mistletoe is Awesome</h1>
<ul id="my-list" class="foo">
    <li class="bar-items">Item One</li>
    <li class="bar-items">Item Two</li>
    <li class="bar-items">Item Three</li>
</ul>
```