### PR TITLE
Merge block_token._root_node and span_token._root_node into a single object

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -22,15 +22,6 @@ __all__ = ['BlockCode', 'Heading', 'Quote', 'CodeFence', 'ThematicBreak',
            'List', 'Table', 'Footnote', 'Paragraph']
 
 
-"""
-Stores a reference to the current document token.
-
-When parsing, footnote entries will be stored in the document by
-accessing this pointer.
-"""
-_root_node = None
-
-
 def tokenize(lines):
     """
     A wrapper around block_tokenizer.tokenize. Pass in all block-level
@@ -143,12 +134,9 @@ class Document(BlockToken):
             lines = lines.splitlines(keepends=True)
         lines = [line if line.endswith('\n') else '{}\n'.format(line) for line in lines]
         self.footnotes = {}
-        global _root_node
-        _root_node = self
-        span_token._root_node = self
+        token._root_node = self
         self.children = tokenize(lines)
-        span_token._root_node = None
-        _root_node = None
+        token._root_node = None
 
 
 class Heading(BlockToken):
@@ -777,7 +765,7 @@ class Footnote(BlockToken):
                 break
             offset, match = match_info
             matches.append(match)
-        cls.append_footnotes(matches, _root_node)
+        cls.append_footnotes(matches, token._root_node)
         return matches or None
 
     @classmethod

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -15,9 +15,6 @@ __all__ = ['EscapeSequence', 'Strikethrough', 'AutoLink', 'CoreTokens',
            'InlineCode', 'LineBreak', 'RawText']
 
 
-_root_node = None
-
-
 def tokenize_inner(content):
     """
     A wrapper around span_tokenizer.tokenize. Pass in all span-level token
@@ -94,7 +91,7 @@ class CoreTokens(SpanToken):
 
     @classmethod
     def find(cls, string):
-        return core_tokens.find_core_tokens(string, _root_node)
+        return core_tokens.find_core_tokens(string, token._root_node)
 
 
 class Strong(SpanToken):

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -3,6 +3,14 @@ Base token class.
 """
 
 
+"""
+Stores a reference to the current document (root) token during parsing.
+
+Footnotes are stored in the document token by accessing this reference.
+"""
+_root_node = None
+
+
 def _short_repr(value):
     """
     Return a shortened ``repr`` output of value for use in ``__repr__`` methods.

--- a/test/test_contrib/test_github_wiki.py
+++ b/test/test_contrib/test_github_wiki.py
@@ -1,12 +1,12 @@
 from unittest import TestCase, mock
-from mistletoe import span_token, Document
+from mistletoe import span_token, Document, token
 from mistletoe.span_token import tokenize_inner
 from contrib.github_wiki import GithubWiki, GithubWikiRenderer
 
 
 class TestGithubWiki(TestCase):
     def setUp(self):
-        span_token._root_node = Document([])
+        token._root_node = Document([])
         self.renderer = GithubWikiRenderer()
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)


### PR DESCRIPTION
This is a proposed refactoring to clean up the state management during parsing a tiny little bit. Instead of having separate _root_node references in the block_token and span_token modules, we merge the two into one and move it to a module already referenced by both of them: token.py.