### PR TITLE
Improvements to metadata handling

### DIFF
--- a/mistletoe/ast_renderer.py
+++ b/mistletoe/ast_renderer.py
@@ -33,9 +33,13 @@ def get_ast(token):
     #   [1]: https://docs.python.org/3/whatsnew/3.6.html
     #   [2]: https://github.com/syntax-tree/mdast
     node['type'] = token.__class__.__name__
-    node.update(token.__dict__)
-    if 'header' in node:
-        node['header'] = get_ast(node['header'])
-    if 'children' in node:
-        node['children'] = [get_ast(child) for child in node['children']]
+    for attrname in ['content', 'footnotes']:
+        if attrname in vars(token):
+            node[attrname] = getattr(token, attrname)
+    for attrname in token.repr_attributes:
+        node[attrname] = getattr(token, attrname)
+    if 'header' in vars(token):
+        node['header'] = get_ast(getattr(token, 'header'))
+    if 'children' in vars(token):
+        node['children'] = [get_ast(child) for child in token.children]
     return node

--- a/mistletoe/token.py
+++ b/mistletoe/token.py
@@ -54,14 +54,14 @@ class Token:
             self.__class__.__name__
         )
 
-        if hasattr(self, "children"):
+        if "children" in vars(self):
             count = len(self.children)
             if count == 1:
                 output += " with 1 child"
             else:
                 output += " with {} children".format(count)
 
-        if hasattr(self, "content"):
+        if "content" in vars(self):
            output += " content=" + _short_repr(self.content)
 
         for attrname in self.repr_attributes:

--- a/test/test_ast_renderer.py
+++ b/test/test_ast_renderer.py
@@ -52,3 +52,57 @@ class TestASTRenderer(unittest.TestCase):
                  }]}
         output = ast_renderer.get_ast(d)
         self.assertEqual(output, target)
+
+    def test_table(self):
+        self.maxDiff = None
+        d = Document(
+            [
+                "| A   | B   |\n",
+                "| --- | --- |\n",
+                "| 1   | 2   |\n",
+            ]
+        )
+        target = {
+            "type": "Document",
+            "footnotes": {},
+            "children": [{
+                "type": "Table",
+                "column_align": [None, None],
+                "header": {
+                    "type": "TableRow",
+                    "row_align": [None, None],
+                    "children": [{
+                        "type": "TableCell",
+                        "align": None,
+                        "children": [{
+                            "type": "RawText",
+                            "content": "A",
+                    }]}, {
+                        "type": "TableCell",
+                        "align": None,
+                        "children": [{
+                            "type": "RawText",
+                            "content": "B",
+                    }]}],
+                },
+                "children": [{
+                    "type": "TableRow",
+                    "row_align": [None, None],
+                    "children": [{
+                        "type": "TableCell",
+                        "align": None,
+                        "children": [{
+                            "type": "RawText",
+                            "content": "1",
+                    }]}, {
+                        "type": "TableCell",
+                        "align": None,
+                        "children": [{
+                            "type": "RawText",
+                            "content": "2",
+                    }]}],
+                }],
+            }],
+        }
+        output = ast_renderer.get_ast(d)
+        self.assertEqual(output, target)

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -18,11 +18,13 @@ class TestRepr(unittest.TestCase):
 
     def test_heading(self):
         doc = Document("# Foo")
-        self._check_repr_matches(doc.children[0], "block_token.Heading with 1 child content='Foo' level=1")
+        self._check_repr_matches(doc.children[0], "block_token.Heading with 1 child level=1")
+        self._check_repr_matches(doc.children[0].children[0], "span_token.RawText content='Foo'")
 
     def test_subheading(self):
         doc = Document("# Foo\n## Bar")
-        self._check_repr_matches(doc.children[1], "block_token.Heading with 1 child content='Bar' level=2")
+        self._check_repr_matches(doc.children[1], "block_token.Heading with 1 child level=2")
+        self._check_repr_matches(doc.children[1].children[0], "span_token.RawText content='Bar'")
 
     def test_quote(self):
         doc = Document("> Foo")


### PR DESCRIPTION
This is an attempt to make the two places in the code base where metadata is handled -- the ASTRenderer and Token.repr -- work in a similar way, and most importantly: to display only selected attributes on the tokens (as specified in repr_attributes), instead of displaying everything it can find. The PR also includes a small bug fix for Token.repr.

This PR was split out from #169.

In more detail:
* Updated the AST renderer to display the "official" attributes on the tokens (as specified in repr_attributes), instead of grabbing all attributes it can find.
* Added footnotes to the repr_attributes on the Document token. This is the only attribute expected by the ASTRenderer test suite which wasn't already listed in repr_attributes.
* Bug fix for Token.repr: only instance attributes should be included in repr, not class attributes. The class attributes are temporary and used during parsing. Affects headings.
