### PR TITLE
weird hack in PygmentsRenderer

### DIFF
--- a/mistletoe/contrib/pygments_renderer.py
+++ b/mistletoe/contrib/pygments_renderer.py
@@ -14,7 +14,7 @@ class PygmentsRenderer(HTMLRenderer):
 
 
     def render_block_code(self, token):
-        code = token.content
+        code = token.children[0].content
         lexer = get_lexer(token.language) if token.language else guess_lexer(code)
         return highlight(code, lexer, self.formatter)
 


### PR DESCRIPTION
the type mistletoe.block_token.BlockCode cannot directly access its attribute content, so I had to do this. :)