### PR TITLE
feat: optional html quotes escaping for HTMLRenderer (#176)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest parameterized
         if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest parameterized
         # note: the following also installs "coverage"
         python -m pip install coveralls
         if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi

--- a/mistletoe/base_renderer.py
+++ b/mistletoe/base_renderer.py
@@ -42,7 +42,7 @@ class BaseRenderer(object):
     """
     _parse_name = re.compile(r"([A-Z][a-z]+|[A-Z]+(?![a-z]))")
 
-    def __init__(self, *extras):
+    def __init__(self, *extras, **kwargs):
         self.render_map = {
             'Strong':         self.render_strong,
             'Emphasis':       self.render_emphasis,

--- a/mistletoe/contrib/github_wiki.py
+++ b/mistletoe/contrib/github_wiki.py
@@ -18,8 +18,13 @@ class GithubWiki(SpanToken):
 
 
 class GithubWikiRenderer(HTMLRenderer):
-    def __init__(self):
-        super().__init__(GithubWiki)
+    def __init__(self, **kwargs):
+        """
+        Args:
+            **kwargs: additional parameters to be passed to the ancestor's
+                      constructor.
+        """
+        super().__init__(GithubWiki, **kwargs)
 
     def render_github_wiki(self, token):
         template = '<a href="{target}">{inner}</a>'

--- a/mistletoe/contrib/mathjax.py
+++ b/mistletoe/contrib/mathjax.py
@@ -6,10 +6,14 @@ from mistletoe.html_renderer import HTMLRenderer
 from mistletoe.latex_renderer import LaTeXRenderer
 
 class MathJaxRenderer(HTMLRenderer, LaTeXRenderer):
-    """
-    MRO will first look for render functions under HTMLRenderer,
-    then LaTeXRenderer.
-    """
+    def __init__(self, **kwargs):
+        """
+        Args:
+            **kwargs: additional parameters to be passed to the ancestors'
+                      constructors.
+        """
+        super().__init__(**kwargs)
+
     mathjax_src = '<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML"></script>\n'
 
     def render_math(self, token):

--- a/mistletoe/contrib/toc_renderer.py
+++ b/mistletoe/contrib/toc_renderer.py
@@ -11,16 +11,19 @@ from mistletoe import block_token
 class TOCRenderer(HTMLRenderer):
     """
     Extends HTMLRenderer class for table of contents support.
-
-    Args:
-        depth (int): the maximum level of heading to be included in TOC;
-        omit_title (bool): whether to ignore tokens where token.level == 1;
-        filter_conds (list): when any of these functions evaluate to true,
-                             current heading will not be included;
-        extras (list): allows subclasses to add even more custom tokens.
     """
-    def __init__(self, depth=5, omit_title=True, filter_conds=[], *extras):
-        super().__init__(*extras)
+    def __init__(self, *extras, depth=5, omit_title=True, filter_conds=[], **kwargs):
+        """
+        Args:
+            extras (list): allows subclasses to add even more custom tokens.
+            depth (int): the maximum level of heading to be included in TOC.
+            omit_title (bool): whether to ignore tokens where token.level == 1.
+            filter_conds (list): when any of these functions evaluate to true,
+                                current heading will not be included.
+            **kwargs: additional parameters to be passed to the ancestor's
+                      constructor.
+        """
+        super().__init__(*extras, **kwargs)
         self._headings = []
         self.depth = depth
         self.omit_title = omit_title

--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -18,7 +18,7 @@ class HTMLRenderer(BaseRenderer):
 
     See mistletoe.base_renderer module for more info.
     """
-    def __init__(self, *extras, html_escape_double_quotes=True, html_escape_single_quotes=False):
+    def __init__(self, *extras, html_escape_double_quotes=True, html_escape_single_quotes=False, **kwargs):
         """
         Args:
             extras (list): allows subclasses to add even more custom tokens.
@@ -26,9 +26,11 @@ class HTMLRenderer(BaseRenderer):
                 quotes when HTML-escaping rendered text.
             html_escape_single_quotes (bool): whether to also escape single
                 quotes when HTML-escaping rendered text.
+            **kwargs: additional parameters to be passed to the ancestor's
+                constructor.
         """
         self._suppress_ptag_stack = [False]
-        super().__init__(*chain((HTMLBlock, HTMLSpan), extras))
+        super().__init__(*chain((HTMLBlock, HTMLSpan), extras), **kwargs)
         self.html_escape_double_quotes = html_escape_double_quotes
         self.html_escape_single_quotes = html_escape_single_quotes
 

--- a/mistletoe/latex_renderer.py
+++ b/mistletoe/latex_renderer.py
@@ -17,15 +17,17 @@ for delimiter in reversed('|!"\'=+'):  # start with most common delimiters
 
 
 class LaTeXRenderer(BaseRenderer):
-    def __init__(self, *extras):
+    def __init__(self, *extras, **kwargs):
         """
         Args:
             extras (list): allows subclasses to add even more custom tokens.
+            **kwargs: additional parameters to be passed to the ancestor's
+                      constructor.
         """
         tokens = self._tokens_from_module(latex_token)
         self.packages = {}
         self.verb_delimiters = verb_delimiters
-        super().__init__(*chain(tokens, extras))
+        super().__init__(*chain(tokens, extras), **kwargs)
 
     def render_strong(self, token):
         return '\\textbf{{{}}}'.format(self.render_inner(token))

--- a/test/specification/commonmark.py
+++ b/test/specification/commonmark.py
@@ -34,7 +34,7 @@ def run_tests(test_entries, start=None, end=None,
 def run_test(test_entry, quiet=False):
     test_case = test_entry['markdown'].splitlines(keepends=True)
     try:
-        output = markdown(test_case).replace('&#x27;', "'")
+        output = markdown(test_case)
         success = test_entry['html'] == output
         if not success and not quiet:
             print_test_entry(test_entry, output)

--- a/test/test_html_renderer.py
+++ b/test/test_html_renderer.py
@@ -1,6 +1,6 @@
 from unittest import TestCase, mock
 from mistletoe.html_renderer import HTMLRenderer
-
+from parameterized import parameterized
 
 class TestRenderer(TestCase):
     def setUp(self):
@@ -136,6 +136,19 @@ class TestHTMLRenderer(TestRenderer):
 
     def test_document(self):
         self._test_token('Document', '', footnotes={})
+
+
+class TestHTMLRendererEscaping(TestCase):
+    @parameterized.expand([
+        (False, False, '" and \''),
+        (False, True, '" and &#x27;'),
+        (True, False, '&quot; and \''),
+        (True, True, '&quot; and &#x27;'),
+    ])
+    def test_escape_html_text(self, escape_double, escape_single, expected):
+        with HTMLRenderer(html_escape_double_quotes=escape_double,
+                          html_escape_single_quotes=escape_single) as renderer:
+            self.assertEqual(renderer.escape_html_text('" and \''), expected)
 
 
 class TestHTMLRendererFootnotes(TestCase):


### PR DESCRIPTION
Introduce additional parameters for the `HTMLRenderer` constructor that control double and single quotes escaping.
Also revert to previous behavior when single quotes are not escaped (by default).