### PR TITLE
fixing "pygments.util.ClassNotFound: no lexer for alias" error

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest parameterized
+        python -m pip install flake8 pytest parameterized pygments
         if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest parameterized
+        python -m pip install pytest parameterized pygments
         # note: the following also installs "coverage"
         python -m pip install coveralls
         if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi

--- a/mistletoe/contrib/pygments_renderer.py
+++ b/mistletoe/contrib/pygments_renderer.py
@@ -1,20 +1,32 @@
 from mistletoe import HTMLRenderer
 from pygments import highlight
-from pygments.styles import get_style_by_name as get_style
-from pygments.lexers import get_lexer_by_name as get_lexer, guess_lexer
 from pygments.formatters.html import HtmlFormatter
+from pygments.lexers import get_lexer_by_name as get_lexer, guess_lexer
+from pygments.styles import get_style_by_name as get_style
+from pygments.util import ClassNotFound
+
 
 class PygmentsRenderer(HTMLRenderer):
     formatter = HtmlFormatter()
     formatter.noclasses = True
 
-    def __init__(self, *extras, style='default'):
+    def __init__(self, *extras, style='default', fail_on_unsupported_language=False):
         super().__init__(*extras)
         self.formatter.style = get_style(style)
-
+        self.fail_on_unsupported_language = fail_on_unsupported_language
 
     def render_block_code(self, token):
         code = token.content
-        lexer = get_lexer(token.language) if token.language else guess_lexer(code)
-        return highlight(code, lexer, self.formatter)
+        lexer = None
 
+        if token.language:
+            try:
+                lexer = get_lexer(token.language)
+            except ClassNotFound as err:
+                if self.fail_on_unsupported_language:
+                    raise err
+
+        if lexer is None:
+            lexer = guess_lexer(code)
+
+        return highlight(code, lexer, self.formatter)

--- a/test/test_contrib/test_pygments_renderer.py
+++ b/test/test_contrib/test_pygments_renderer.py
@@ -7,7 +7,7 @@ from pygments.util import ClassNotFound
 
 
 class TestPygmentsRenderer(unittest.TestCase):
-    @parameterized.expand([(True), (False)])
+    @parameterized.expand([(True,), (False,)])
     def test_render_no_language(self, fail_on_unsupported_language: bool):
         renderer = PygmentsRenderer(fail_on_unsupported_language=fail_on_unsupported_language)
         token = Document(['```\n', 'no language\n', '```\n'])

--- a/test/test_contrib/test_pygments_renderer.py
+++ b/test/test_contrib/test_pygments_renderer.py
@@ -1,0 +1,46 @@
+import unittest
+
+from mistletoe import Document
+from mistletoe.contrib.pygments_renderer import PygmentsRenderer
+from parameterized import parameterized
+from pygments.util import ClassNotFound
+
+
+class TestPygmentsRenderer(unittest.TestCase):
+    @parameterized.expand([(True), (False)])
+    def test_render_no_language(self, fail_on_unsupported_language: bool):
+        renderer = PygmentsRenderer(fail_on_unsupported_language=fail_on_unsupported_language)
+        token = Document(['```\n', 'no language\n', '```\n'])
+        output = renderer.render(token)
+        actual = (
+            '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;">'
+            '<span></span>no language\n</pre></div>\n\n'
+        )
+        self.assertEqual(output, actual)
+
+    def test_render_known_language(self):
+        renderer = PygmentsRenderer()
+        token = Document(['```python\n', '# python language\n', '```\n'])
+        output = renderer.render(token)
+        actual = (
+            '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;">'
+            '<span></span><span style="color: #3D7B7B; font-style: italic"># python language</span>\n'
+            '</pre></div>\n\n'
+        )
+        self.assertEqual(output, actual)
+
+    def test_render_unknown_language(self):
+        renderer = PygmentsRenderer()
+        token = Document(['```foobar\n', 'unknown language\n', '```\n'])
+        output = renderer.render(token)
+        actual = (
+            '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;">'
+            '<span></span>unknown language\n</pre></div>\n\n'
+        )
+        self.assertEqual(output, actual)
+
+    def test_render_fail_on_unsupported_language(self):
+        renderer = PygmentsRenderer(fail_on_unsupported_language=True)
+        token = Document(['```foobar\n', 'unknown language\n', '```\n'])
+        with self.assertRaises(ClassNotFound):
+            renderer.render(token)


### PR DESCRIPTION
this fixes an error when an unknown language is encountered in the PygmentsRenderer