### PR TITLE
test: unify assertEqual calls in all the tests

### DIFF
--- a/test/test_ast_renderer.py
+++ b/test/test_ast_renderer.py
@@ -6,7 +6,7 @@ class TestASTRenderer(unittest.TestCase):
         self.maxDiff = None
         d = Document(['# heading 1\n', '\n', 'hello\n', 'world\n'])
         output = ast_renderer.get_ast(d)
-        target = {'type': 'Document',
+        expected = {'type': 'Document',
                   'footnotes': {},
                   'children': [{
                       'type': 'Heading',
@@ -29,14 +29,14 @@ class TestASTRenderer(unittest.TestCase):
                           'content': 'world'
                       }]
                  }]}
-        self.assertEqual(output, target)
+        self.assertEqual(output, expected)
 
     def test_footnotes(self):
         self.maxDiff = None
         d = Document(['[bar][baz]\n',
                       '\n',
                       '[baz]: spam\n'])
-        target = {'type': 'Document',
+        expected = {'type': 'Document',
                   'footnotes': {'baz': ('spam', '')},
                   'children': [{
                       'type': 'Paragraph',
@@ -51,7 +51,7 @@ class TestASTRenderer(unittest.TestCase):
                       }]
                  }]}
         output = ast_renderer.get_ast(d)
-        self.assertEqual(output, target)
+        self.assertEqual(output, expected)
 
     def test_table(self):
         self.maxDiff = None
@@ -62,7 +62,7 @@ class TestASTRenderer(unittest.TestCase):
                 "| 1   | 2   |\n",
             ]
         )
-        target = {
+        expected = {
             "type": "Document",
             "footnotes": {},
             "children": [{
@@ -105,4 +105,4 @@ class TestASTRenderer(unittest.TestCase):
             }],
         }
         output = ast_renderer.get_ast(d)
-        self.assertEqual(output, target)
+        self.assertEqual(output, expected)

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -48,9 +48,9 @@ class TestJIRARenderer(BaseRendererTest):
     def textFormatTest(self, inputTemplate, outputTemplate):
         input = self.genRandomString(80, False)
         token = next(iter(tokenize_inner(inputTemplate.format(input))))
+        output = self.renderer.render(token)
         expected = outputTemplate.format(input)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
 
     def test_escape_simple(self):
         self.textFormatTest('---fancy text---', '\\-\\-\\-fancy text\\-\\-\\-')
@@ -84,33 +84,33 @@ class TestJIRARenderer(BaseRendererTest):
 
     def test_render_image(self):
         token = next(iter(tokenize_inner('![image](foo.jpg)')))
+        output = self.renderer.render(token)
         expected = '!foo.jpg!'
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
     
     def test_render_footnote_image(self):
         # token = next(tokenize_inner('![image]\n\n[image]: foo.jpg'))
+        # output = self.renderer.render(token)
         # expected = '!foo.jpg!'
-        # actual = self.renderer.render(token)
-        # self.assertEqual(expected, actual)
+        # self.assertEqual(output, expected)
         pass
 
     def test_render_link(self):
         url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
         body = self.genRandomString(80, True)
         token = next(iter(tokenize_inner('[{body}]({url})'.format(url=url, body=body))))
+        output = self.renderer.render(token)
         expected = '[{body}|{url}]'.format(url=url, body=body)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
 
     def test_render_link_with_title(self):
         url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
         body = self.genRandomString(80, True)
         title = self.genRandomString(20, True)
         token = next(iter(tokenize_inner('[{body}]({url} "{title}")'.format(url=url, body=body, title=title))))
+        output = self.renderer.render(token)
         expected = '[{body}|{url}|{title}]'.format(url=url, body=body, title=title)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
     
     def test_render_footnote_link(self):
         pass
@@ -118,9 +118,9 @@ class TestJIRARenderer(BaseRendererTest):
     def test_render_auto_link(self):
         url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
         token = next(iter(tokenize_inner('<{url}>'.format(url=url))))
+        output = self.renderer.render(token)
         expected = '[{url}]'.format(url=url)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
         
     def test_render_escape_sequence(self):
         pass

--- a/test/test_contrib/test_pygments_renderer.py
+++ b/test/test_contrib/test_pygments_renderer.py
@@ -12,32 +12,32 @@ class TestPygmentsRenderer(unittest.TestCase):
         renderer = PygmentsRenderer(fail_on_unsupported_language=fail_on_unsupported_language)
         token = Document(['```\n', 'no language\n', '```\n'])
         output = renderer.render(token)
-        actual = (
+        expected = (
             '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;">'
             '<span></span>no language\n</pre></div>\n\n'
         )
-        self.assertEqual(output, actual)
+        self.assertEqual(output, expected)
 
     def test_render_known_language(self):
         renderer = PygmentsRenderer()
         token = Document(['```python\n', '# python language\n', '```\n'])
         output = renderer.render(token)
-        actual = (
+        expected = (
             '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;">'
             '<span></span><span style="color: #3D7B7B; font-style: italic"># python language</span>\n'
             '</pre></div>\n\n'
         )
-        self.assertEqual(output, actual)
+        self.assertEqual(output, expected)
 
     def test_render_unknown_language(self):
         renderer = PygmentsRenderer()
         token = Document(['```foobar\n', 'unknown language\n', '```\n'])
         output = renderer.render(token)
-        actual = (
+        expected = (
             '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;">'
             '<span></span>unknown language\n</pre></div>\n\n'
         )
-        self.assertEqual(output, actual)
+        self.assertEqual(output, expected)
 
     def test_render_fail_on_unsupported_language(self):
         renderer = PygmentsRenderer(fail_on_unsupported_language=True)

--- a/test/test_contrib/test_xwiki20_renderer.py
+++ b/test/test_contrib/test_xwiki20_renderer.py
@@ -26,9 +26,9 @@ class TestXWiki20Renderer(BaseRendererTest):
     def textFormatTest(self, inputTemplate, outputTemplate):
         input = self.genRandomString(80, False)
         token = next(iter(tokenize_inner(inputTemplate.format(input))))
+        output = self.renderer.render(token)
         expected = outputTemplate.format(input)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
 
     def test_escaping(self):
         self.textFormatTest('**code: `a = 1;// comment`, plain text URL: http://example.com**',
@@ -48,24 +48,24 @@ class TestXWiki20Renderer(BaseRendererTest):
 
     def test_render_image(self):
         token = next(iter(tokenize_inner('![image](foo.jpg)')))
+        output = self.renderer.render(token)
         expected = '[[image:foo.jpg]]'
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
     
     def test_render_link(self):
         url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
         body = self.genRandomString(80, True)
         token = next(iter(tokenize_inner('[{body}]({url})'.format(url=url, body=body))))
+        output = self.renderer.render(token)
         expected = '[[{body}>>{url}]]'.format(url=url, body=body)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
     
     def test_render_auto_link(self):
         url = 'http://{0}.{1}.{2}'.format(self.genRandomString(5), self.genRandomString(5), self.genRandomString(3))
         token = next(iter(tokenize_inner('<{url}>'.format(url=url))))
+        output = self.renderer.render(token)
         expected = '[[{url}]]'.format(url=url)
-        actual = self.renderer.render(token)
-        self.assertEqual(expected, actual)
+        self.assertEqual(output, expected)
 
     def test_render_html_span(self):
         markdown = 'text styles: <i>italic</i>, <b>bold</b>'

--- a/test/test_html_renderer.py
+++ b/test/test_html_renderer.py
@@ -9,7 +9,7 @@ class TestRenderer(TestCase):
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)
 
-    def _test_token(self, token_name, output, children=True,
+    def _test_token(self, token_name, expected_output, children=True,
                     without_attrs=None, **kwargs):
         render_func = self.renderer.render_map[token_name]
         children = mock.MagicMock(spec=list) if children else None
@@ -17,7 +17,7 @@ class TestRenderer(TestCase):
         without_attrs = without_attrs or []
         for attr in without_attrs:
             delattr(mock_token, attr)
-        self.assertEqual(render_func(mock_token), output)
+        self.assertEqual(render_func(mock_token), expected_output)
 
 
 class TestHTMLRenderer(TestRenderer):
@@ -29,25 +29,25 @@ class TestHTMLRenderer(TestRenderer):
 
     def test_inline_code(self):
         from mistletoe.span_token import tokenize_inner
-        rendered = self.renderer.render(tokenize_inner('`foo`')[0])
-        self.assertEqual(rendered, '<code>foo</code>')
-        rendered = self.renderer.render(tokenize_inner('`` \\[\\` ``')[0])
-        self.assertEqual(rendered, '<code>\\[\\`</code>')
+        output = self.renderer.render(tokenize_inner('`foo`')[0])
+        self.assertEqual(output, '<code>foo</code>')
+        output = self.renderer.render(tokenize_inner('`` \\[\\` ``')[0])
+        self.assertEqual(output, '<code>\\[\\`</code>')
 
     def test_strikethrough(self):
         self._test_token('Strikethrough', '<del>inner</del>')
 
     def test_image(self):
-        output = '<img src="src" alt="" title="title" />'
-        self._test_token('Image', output, src='src', title='title')
+        expected = '<img src="src" alt="" title="title" />'
+        self._test_token('Image', expected, src='src', title='title')
 
     def test_link(self):
-        output = '<a href="target" title="title">inner</a>'
-        self._test_token('Link', output, target='target', title='title')
+        expected = '<a href="target" title="title">inner</a>'
+        self._test_token('Link', expected, target='target', title='title')
 
     def test_autolink(self):
-        output = '<a href="link">inner</a>'
-        self._test_token('AutoLink', output, target='link', mailto=False)
+        expected = '<a href="link">inner</a>'
+        self._test_token('AutoLink', expected, target='link', mailto=False)
 
     def test_escape_sequence(self):
         self._test_token('EscapeSequence', 'inner')
@@ -61,74 +61,74 @@ class TestHTMLRenderer(TestRenderer):
                          children=False, content='<some>text</some>')
 
     def test_heading(self):
-        output = '<h3>inner</h3>'
-        self._test_token('Heading', output, level=3)
+        expected = '<h3>inner</h3>'
+        self._test_token('Heading', expected, level=3)
 
     def test_quote(self):
-        output = '<blockquote>\n</blockquote>'
-        self._test_token('Quote', output)
+        expected = '<blockquote>\n</blockquote>'
+        self._test_token('Quote', expected)
 
     def test_paragraph(self):
         self._test_token('Paragraph', '<p>inner</p>')
 
     def test_block_code(self):
         from mistletoe.block_token import tokenize
-        rendered = self.renderer.render(tokenize(['```sh\n', 'foo\n', '```\n'])[0])
-        output = '<pre><code class="language-sh">foo\n</code></pre>'
-        self.assertEqual(rendered, output)
+        output = self.renderer.render(tokenize(['```sh\n', 'foo\n', '```\n'])[0])
+        expected = '<pre><code class="language-sh">foo\n</code></pre>'
+        self.assertEqual(output, expected)
 
     def test_block_code_no_language(self):
         from mistletoe.block_token import tokenize
-        rendered = self.renderer.render(tokenize(['```\n', 'foo\n', '```\n'])[0])
-        output = '<pre><code>foo\n</code></pre>'
-        self.assertEqual(rendered, output)
+        output = self.renderer.render(tokenize(['```\n', 'foo\n', '```\n'])[0])
+        expected = '<pre><code>foo\n</code></pre>'
+        self.assertEqual(output, expected)
 
     def test_list(self):
-        output = '<ul>\n\n</ul>'
-        self._test_token('List', output, start=None)
+        expected = '<ul>\n\n</ul>'
+        self._test_token('List', expected, start=None)
 
     def test_list_item(self):
-        output = '<li></li>'
-        self._test_token('ListItem', output)
+        expected = '<li></li>'
+        self._test_token('ListItem', expected)
 
     def test_table_with_header(self):
         func_path = 'mistletoe.html_renderer.HTMLRenderer.render_table_row'
         with mock.patch(func_path, autospec=True) as mock_func:
             mock_func.return_value = 'row'
-            output = ('<table>\n'
+            expected = ('<table>\n'
                         '<thead>\nrow</thead>\n'
                         '<tbody>\ninner</tbody>\n'
                       '</table>')
-            self._test_token('Table', output)
+            self._test_token('Table', expected)
 
     def test_table_without_header(self):
         func_path = 'mistletoe.html_renderer.HTMLRenderer.render_table_row'
         with mock.patch(func_path, autospec=True) as mock_func:
             mock_func.return_value = 'row'
-            output = '<table>\n<tbody>\ninner</tbody>\n</table>'
-            self._test_token('Table', output, without_attrs=['header',])
+            expected = '<table>\n<tbody>\ninner</tbody>\n</table>'
+            self._test_token('Table', expected, without_attrs=['header',])
 
     def test_table_row(self):
         self._test_token('TableRow', '<tr>\n</tr>\n')
 
     def test_table_cell(self):
-        output = '<td align="left">inner</td>\n'
-        self._test_token('TableCell', output, align=None)
+        expected = '<td align="left">inner</td>\n'
+        self._test_token('TableCell', expected, align=None)
         
     def test_table_cell0(self):
-        output = '<td align="center">inner</td>\n'
-        self._test_token('TableCell', output, align=0)
+        expected = '<td align="center">inner</td>\n'
+        self._test_token('TableCell', expected, align=0)
         
     def test_table_cell1(self):
-        output = '<td align="right">inner</td>\n'
-        self._test_token('TableCell', output, align=1)
+        expected = '<td align="right">inner</td>\n'
+        self._test_token('TableCell', expected, align=1)
 
     def test_thematic_break(self):
         self._test_token('ThematicBreak', '<hr />', children=False)
 
     def test_html_block(self):
-        content = output = '<h1>hello</h1>\n<p>this is\na paragraph</p>\n'
-        self._test_token('HTMLBlock', output,
+        content = expected = '<h1>hello</h1>\n<p>this is\na paragraph</p>\n'
+        self._test_token('HTMLBlock', expected,
                          children=False, content=content)
 
     def test_line_break(self):
@@ -160,11 +160,11 @@ class TestHTMLRendererFootnotes(TestCase):
     def test_footnote_image(self):
         from mistletoe import Document
         token = Document(['![alt][foo]\n', '\n', '[foo]: bar "title"\n'])
-        output = '<p><img src="bar" alt="alt" title="title" /></p>\n'
-        self.assertEqual(self.renderer.render(token), output)
+        expected = '<p><img src="bar" alt="alt" title="title" /></p>\n'
+        self.assertEqual(self.renderer.render(token), expected)
 
     def test_footnote_link(self):
         from mistletoe import Document
         token = Document(['[name][foo]\n', '\n', '[foo]: target\n'])
-        output = '<p><a href="target">name</a></p>\n' 
-        self.assertEqual(self.renderer.render(token), output)
+        expected = '<p><a href="target">name</a></p>\n' 
+        self.assertEqual(self.renderer.render(token), expected)

--- a/test/test_latex_renderer.py
+++ b/test/test_latex_renderer.py
@@ -11,7 +11,7 @@ class TestLaTeXRenderer(TestCase):
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)
 
-    def _test_token(self, token_name, output, children=True,
+    def _test_token(self, token_name, expected_output, children=True,
                     without_attrs=None, **kwargs):
         render_func = self.renderer.render_map[token_name]
         children = mock.MagicMock(spec=list) if children else None
@@ -19,7 +19,7 @@ class TestLaTeXRenderer(TestCase):
         without_attrs = without_attrs or []
         for attr in without_attrs:
             delattr(mock_token, attr)
-        self.assertEqual(render_func(mock_token), output)
+        self.assertEqual(render_func(mock_token), expected_output)
 
     def test_strong(self):
         self._test_token('Strong', '\\textbf{inner}')
@@ -141,23 +141,23 @@ class TestLaTeXFootnotes(TestCase):
     def test_footnote_image(self):
         from mistletoe import Document
         raw = ['![alt][foo]\n', '\n', '[foo]: bar "title"\n']
-        target = ('\\documentclass{article}\n'
+        expected = ('\\documentclass{article}\n'
                   '\\usepackage{graphicx}\n'
                   '\\begin{document}\n'
                   '\n'
                   '\n\\includegraphics{bar}\n'
                   '\n'
                   '\\end{document}\n')
-        self.assertEqual(self.renderer.render(Document(raw)), target)
+        self.assertEqual(self.renderer.render(Document(raw)), expected)
 
     def test_footnote_link(self):
         from mistletoe import Document
         raw = ['[name][key]\n', '\n', '[key]: target\n']
-        target = ('\\documentclass{article}\n'
+        expected = ('\\documentclass{article}\n'
                   '\\usepackage{hyperref}\n'
                   '\\begin{document}\n'
                   '\n'
                   '\\href{target}{name}'
                   '\n'
                   '\\end{document}\n')
-        self.assertEqual(self.renderer.render(Document(raw)), target)
+        self.assertEqual(self.renderer.render(Document(raw)), expected)

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -14,8 +14,8 @@ class TestMarkdownRenderer(unittest.TestCase):
 
     def test_empty_document(self):
         input = []
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_paragraphs_and_blank_lines(self):
         input = [
@@ -25,9 +25,9 @@ class TestMarkdownRenderer(unittest.TestCase):
             "Paragraph 2. Two\n",
             "lines, no final line break.",
         ]
-        rendered = self.roundtrip(input)
+        output = self.roundtrip(input)
         # note: a line break is always added at the end of a paragraph.
-        self.assertEqual(rendered, "".join(input) + "\n")
+        self.assertEqual(output, "".join(input) + "\n")
 
     def test_line_breaks(self):
         input = [
@@ -37,35 +37,35 @@ class TestMarkdownRenderer(unittest.TestCase):
             "yet another hard line break    \n",
             "that's all.\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_emphasized_and_strong(self):
         input = ["*emphasized* __strong__ _**emphasized and strong**_\n"]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_strikethrough(self):
         input = ["~~strikethrough~~\n"]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_escaped_chars(self):
         input = ["\\*escaped, not emphasized\\*\n"]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_html_span(self):
         input = ["so <p>hear ye</p><h1>\n"]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_code_span(self):
         input = [
             "a) `code span` b) ``trailing space, double apostrophes `` c) ` leading and trailing space `\n"
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_code_span_with_embedded_line_breaks(self):
         input = [
@@ -73,11 +73,11 @@ class TestMarkdownRenderer(unittest.TestCase):
             "code\n",
             "span`.\n"
         ]
+        output = self.roundtrip(input)
         expected = [
             "a `multi-line code span`.\n"
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(expected))
+        self.assertEqual(output, "".join(expected))
 
     def test_images_and_links(self):
         input = [
@@ -87,16 +87,16 @@ class TestMarkdownRenderer(unittest.TestCase):
             '![an \\[*image*\\], escapes and emphasis](#url "title")\n',
             "<http://auto.link>\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_thematic_break(self):
         input = [
             " **  * ** * ** * **\n",
             "followed by a paragraph of text\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_atx_headings(self):
         input = [
@@ -105,8 +105,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "###\n",
             "^ empty atx heading\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_setext_headings(self):
         input = [
@@ -114,8 +114,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "heading!\n",
             "===============\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_numbered_list(self):
         input = [
@@ -125,6 +125,7 @@ class TestMarkdownRenderer(unittest.TestCase):
             "       + apples\n",
             "       +  bananas\n",
         ]
+        output = self.roundtrip(input)
         expected = [
             "22) *emphasized list item*\n",
             "96) \n",
@@ -132,8 +133,7 @@ class TestMarkdownRenderer(unittest.TestCase):
             "     + apples\n",
             "     + bananas\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(expected))
+        self.assertEqual(output, "".join(expected))
 
     def test_bulleted_list(self):
         input = [
@@ -143,8 +143,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "\n",
             "[properly]: uri\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_code_blocks(self):
         input = [
@@ -163,8 +163,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "\n",
             "       indented code block.\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_blank_lines_following_code_block(self):
         input = [
@@ -172,8 +172,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "\n",
             "paragraph.\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_html_block(self):
         input = [
@@ -183,8 +183,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "+ <h1>html block embedded in list <img src='https://cdn.rawgit.com/' align='right'></h1>\n",
             "  <br>\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_block_quote(self):
         input = [
@@ -193,8 +193,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "> 1. > and finally, a list with a nested block quote\n",
             ">    > which continues on a second line.\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_link_reference_definition(self):
         input = [
@@ -208,8 +208,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "with line break'\n",
             "[label-not-referred-to]: https://foo (title)\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_table(self):
         input = [
@@ -219,8 +219,8 @@ class TestMarkdownRenderer(unittest.TestCase):
             "|   🐎   | Performance improvements. |\n",
             "etc, etc\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(input))
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
 
     def test_table_with_varying_column_counts(self):
         input = [
@@ -229,14 +229,14 @@ class TestMarkdownRenderer(unittest.TestCase):
             "   | . | Performance improvements. | an extra column |   \n",
             "etc, etc\n",
         ]
+        output = self.roundtrip(input)
         expected = [
             "| header |                         x |                 |\n",
             "| ------ | ------------------------: | --------------- |\n",
             "| .      | Performance improvements. | an extra column |\n",
             "etc, etc\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(expected))
+        self.assertEqual(output, "".join(expected))
 
     def test_table_with_narrow_column(self):
         input = [
@@ -245,14 +245,14 @@ class TestMarkdownRenderer(unittest.TestCase):
             "| a   | p |\n",
             "| b   | q |\n",
         ]
+        output = self.roundtrip(input)
         expected = [
             "| xyz | ?   |\n",
             "| --- | --- |\n",
             "| a   | p   |\n",
             "| b   | q   |\n",
         ]
-        rendered = self.roundtrip(input)
-        self.assertEqual(rendered, "".join(expected))
+        self.assertEqual(output, "".join(expected))
 
     def test_direct_rendering_of_block_token(self):
         input = [


### PR DESCRIPTION
It's easy and unified now (with no exceptions, right?! :)):

1. As per unittest's documentation examples, `actual` always goes before `expected`.
2. If used, `actual` is stored in a variable `output` for us.
3. If used, variable `expected` is defined after the `output` variable.

For curious ones, Python (as well as the rest of the world) is not consistent here: https://stackoverflow.com/questions/40945126/parameter-order-for-unittest-testcase-assertequal.