### PR TITLE
Changed FileWrapper anchor/reset to getpos/setpos.

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -102,8 +102,8 @@ class BlockToken(token.Token):
 
           If BlockToken.read returns None, the read result is ignored,
           but the token class is responsible for resetting the iterator
-          to a previous state. See block_tokenizer.FileWrapper.getpos,
-          block_tokenizer.FileWrapper.setpos.
+          to a previous state. See block_tokenizer.FileWrapper.get_pos,
+          block_tokenizer.FileWrapper.set_pos.
 
     Attributes:
         children (list): inner tokens.
@@ -491,13 +491,13 @@ class List(BlockToken):
         next_marker = None
         matches = []
         while True:
-            anchor = lines.getpos()
+            anchor = lines.get_pos()
             output, next_marker = ListItem.read(lines, next_marker)
             item_leader = output[2]
             if leader is None:
                 leader = item_leader
             elif not cls.same_marker_type(leader, item_leader):
-                lines.setpos(anchor)
+                lines.set_pos(anchor)
                 break
             matches.append(output)
             if next_marker is None:
@@ -714,12 +714,12 @@ class Table(BlockToken):
 
     @staticmethod
     def read(lines):
-        anchor = lines.getpos()
+        anchor = lines.get_pos()
         line_buffer = [next(lines)]
         while lines.peek() is not None and '|' in lines.peek():
             line_buffer.append(next(lines))
         if len(line_buffer) < 2 or '---' not in line_buffer[1]:
-            lines.setpos(anchor)
+            lines.set_pos(anchor)
             return None
         return line_buffer
 

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -102,8 +102,8 @@ class BlockToken(token.Token):
 
           If BlockToken.read returns None, the read result is ignored,
           but the token class is responsible for resetting the iterator
-          to a previous state. See block_tokenizer.FileWrapper.anchor,
-          block_tokenizer.FileWrapper.reset.
+          to a previous state. See block_tokenizer.FileWrapper.getpos,
+          block_tokenizer.FileWrapper.setpos.
 
     Attributes:
         children (list): inner tokens.
@@ -491,12 +491,13 @@ class List(BlockToken):
         next_marker = None
         matches = []
         while True:
+            anchor = lines.getpos()
             output, next_marker = ListItem.read(lines, next_marker)
             item_leader = output[2]
             if leader is None:
                 leader = item_leader
             elif not cls.same_marker_type(leader, item_leader):
-                lines.reset()
+                lines.setpos(anchor)
                 break
             matches.append(output)
             if next_marker is None:
@@ -594,7 +595,6 @@ class ListItem(BlockToken):
     @classmethod
     def read(cls, lines, prev_marker=None):
         next_marker = None
-        lines.anchor()
         line_buffer = []
 
         # first line
@@ -714,12 +714,12 @@ class Table(BlockToken):
 
     @staticmethod
     def read(lines):
-        lines.anchor()
+        anchor = lines.getpos()
         line_buffer = [next(lines)]
         while lines.peek() is not None and '|' in lines.peek():
             line_buffer.append(next(lines))
         if len(line_buffer) < 2 or '---' not in line_buffer[1]:
-            lines.reset()
+            lines.setpos(anchor)
             return None
         return line_buffer
 

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -7,7 +7,6 @@ class FileWrapper:
     def __init__(self, lines):
         self.lines = lines if isinstance(lines, list) else list(lines)
         self._index = -1
-        self._anchor = 0
 
     def __next__(self):
         if self._index + 1 < len(self.lines):
@@ -21,11 +20,11 @@ class FileWrapper:
     def __repr__(self):
         return repr(self.lines[self._index+1:])
 
-    def anchor(self):
-        self._anchor = self._index
+    def getpos(self):
+        return self._index
 
-    def reset(self):
-        self._index = self._anchor
+    def setpos(self, pos):
+        self._index = pos
 
     def peek(self):
         if self._index + 1 < len(self.lines):

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -7,6 +7,7 @@ class FileWrapper:
     def __init__(self, lines):
         self.lines = lines if isinstance(lines, list) else list(lines)
         self._index = -1
+        self._anchor = 0
 
     def __next__(self):
         if self._index + 1 < len(self.lines):
@@ -29,6 +30,13 @@ class FileWrapper:
         """Sets the current reading position."""
         self._index = pos
 
+    def anchor(self):
+        """@deprecated use `get_pos` instead"""
+        self._anchor = self.get_pos()
+
+    def reset(self):
+        """@deprecated use `set_pos` instead"""
+        self.set_pos(self._anchor)
     def peek(self):
         if self._index + 1 < len(self.lines):
             return self.lines[self._index+1]

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -20,10 +20,13 @@ class FileWrapper:
     def __repr__(self):
         return repr(self.lines[self._index+1:])
 
-    def getpos(self):
+    def get_pos(self):
+        """Returns the current reading position.
+        The result is an opaque value which can be passed to `set_pos`."""
         return self._index
 
-    def setpos(self, pos):
+    def set_pos(self, pos):
+        """Sets the current reading position."""
         self._index = pos
 
     def peek(self):

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -37,6 +37,7 @@ class FileWrapper:
     def reset(self):
         """@deprecated use `set_pos` instead"""
         self.set_pos(self._anchor)
+
     def peek(self):
         if self._index + 1 < len(self.lines):
             return self.lines[self._index+1]

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import patch, call
-from mistletoe import block_token, span_token
+from unittest.mock import call, patch
+
+from mistletoe import block_token, block_tokenizer, span_token
 
 
 class TestToken(unittest.TestCase):
@@ -604,3 +605,31 @@ class TestLeafBlockTokenContentProperty(unittest.TestCase):
 
         # option 2: using property getter to access the content
         self.assertEqual(''.join(lines).strip(), tokens[0].content)
+
+
+class TestFileWrapper(unittest.TestCase):
+    def test_get_set_pos(self):
+        lines = [
+            "# heading\n",
+            "somewhat interesting\n",
+            "content\n",
+        ]
+        wrapper = block_tokenizer.FileWrapper(lines)
+        assert next(wrapper) == "# heading\n"
+        anchor = wrapper.get_pos()
+        assert next(wrapper) == "somewhat interesting\n"
+        wrapper.set_pos(anchor)
+        assert next(wrapper) == "somewhat interesting\n"
+
+    def test_anchor_reset(self):
+        lines = [
+            "# heading\n",
+            "somewhat interesting\n",
+            "content\n",
+        ]
+        wrapper = block_tokenizer.FileWrapper(lines)
+        assert next(wrapper) == "# heading\n"
+        wrapper.anchor()
+        assert next(wrapper) == "somewhat interesting\n"
+        wrapper.reset()
+        assert next(wrapper) == "somewhat interesting\n"


### PR DESCRIPTION
Issue found during implementation of #166, when checking for the start of `Table` tokens.

When checking if a table starts on a line, one needs to scan multiple lines without consuming any content. The way to do this is with the anchor/reset methods on the `FileWrapper` class. However, this breaks the parsing of `List` tokens, because these also use anchor/reset, and the anchor set by `List` gets overwritten by the one set in `Table`.

The proposed solution is to not store the anchor position on the `FileWrapper`, but instead move that responsibility to the parsing method. This way, recursive parsing can hold multiple anchors at the same time, without any interference.