### PR TITLE
Make tables interrupt paragraphs (#166)

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -667,11 +667,17 @@ class Table(BlockToken):
     Table token.
     This is a container block token. Its children are TableRow tokens.
 
+    Class attributes:
+        interrupt_paragraph: indicates whether tables should interrupt paragraphs
+        during parsing. The default is true.
+
     Attributes:
         header: header row (TableRow).
         column_align (list): align options for each column (default to [None]).
     """
     repr_attributes = ("column_align",)
+    interrupt_paragraph = True
+
     def __init__(self, lines):
         if '---' in lines[1]:
             self.column_align = [self.parse_align(column)
@@ -714,6 +720,8 @@ class Table(BlockToken):
 
     @classmethod
     def check_interrupts_paragraph(cls, lines):
+        if not cls.interrupt_paragraph:
+            return False
         anchor = lines.get_pos()
         result = cls.read(lines)
         lines.set_pos(anchor)

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -712,6 +712,13 @@ class Table(BlockToken):
     def start(line):
         return '|' in line
 
+    @classmethod
+    def check_interrupts_paragraph(cls, lines):
+        anchor = lines.get_pos()
+        result = cls.read(lines)
+        lines.set_pos(anchor)
+        return result
+
     @staticmethod
     def read(lines):
         anchor = lines.get_pos()

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -160,10 +160,11 @@ class TestParagraph(TestToken):
             '<div>\n', # HTML block type 6
             '> block quote\n',
             '1. list\n',
-            '``` fenced code block\n'
+            '``` fenced code block\n',
+            ('| table |\n', '| ----- |\n', '| row   |\n'),
         ]
         for block in interrupting_blocks:
-            lines = ['Paragraph 1\n', block]
+            lines = ['Paragraph 1\n', *block]
         try:
             token1, token2 = block_token.tokenize(lines)
         except ValueError as e:
@@ -176,9 +177,6 @@ class TestParagraph(TestToken):
             'Paragraph 1\n',
             '2. list\n', # list doesn't start from 1
             '    indented text\n', # code block
-            '| table |\n', # table
-            '| ----- |\n',
-            '| row   |\n',
             '<custom>\n', # HTML block type 7
             '\n',
             'Paragraph 2\n'

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -154,29 +154,22 @@ class TestParagraph(TestToken):
         self.assertIsInstance(token3, block_token.Paragraph)
 
     def test_parse_interrupting_block_tokens(self):
-        lines = [
-            'Paragraph 1\n',
+        interrupting_blocks = [
             '***\n', # thematic break
-            'Paragraph 2\n',
             '## atx\n', # ATX heading
-            'Paragraph 3\n',
-            '<html></html>\n', # HTML block type 1
-            'Paragraph 4\n',
+            '<div>\n', # HTML block type 6
             '> block quote\n',
-            'Paragraph 5\n',
             '1. list\n',
-            'Paragraph 6\n',
-            '```\n',
-            'fenced code block\n',
-            '```\n',
-            'Paragraph 7\n'
+            '``` fenced code block\n'
         ]
-        tokens = block_token.tokenize(lines)
-        for index, token in enumerate(tokens):
-            if index % 2 == 0:
-                self.assertIsInstance(token, block_token.Paragraph)
-            else:
-                self.assertNotIsInstance(token, block_token.Paragraph)
+        for block in interrupting_blocks:
+            lines = ['Paragraph 1\n', block]
+        try:
+            token1, token2 = block_token.tokenize(lines)
+        except ValueError as e:
+            raise AssertionError("Token number mismatch. Lines: '{}'".format(lines)) from e
+        self.assertIsInstance(token1, block_token.Paragraph)
+        self.assertNotIsInstance(token2, block_token.Paragraph)
 
     def test_parse_non_interrupting_block_tokens(self):
         lines = [
@@ -185,7 +178,7 @@ class TestParagraph(TestToken):
             '    indented text\n', # code block
             '| table |\n', # table
             '| ----- |\n',
-            '| row   |\n'
+            '| row   |\n',
             '<custom>\n', # HTML block type 7
             '\n',
             'Paragraph 2\n'

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -412,6 +412,22 @@ class TestTable(unittest.TestCase):
         token, = block_token.tokenize(lines)
         self.assertIsInstance(token, block_token.Paragraph)
 
+    def test_interrupt_paragraph_option(self):
+        lines = [
+            'Paragraph 1\n',
+            '| table |\n',
+            '| ----- |\n',
+            '| row   |\n',
+        ]
+        try:
+            block_token.Table.interrupt_paragraph = False
+            token, = block_token.tokenize(lines)
+        except ValueError as e:
+            raise AssertionError("Token number mismatch.") from e
+        finally:
+            block_token.Table.interrupt_paragraph = True
+        self.assertIsInstance(token, block_token.Paragraph)
+
 
 class TestTableRow(unittest.TestCase):
     def test_match(self):


### PR DESCRIPTION
This PR introduces a more modular way to detect when a block token interrupts a paragraph. It also makes `Table` tokens interrupt paragraphs, using the new mechanism.

Adding it as a draft PR for now, due to the dependency on #186 .

In addition to the "obvious" use in `Paragraph.read()`, checks for paragraph interruptions are also done in `Quote.read()` and `ListItem.read()` to determine whether a line is a lazy continuation line or not.

Using the new mechanism to check for continuation lines in `Quote` and `ListItem` does change the parsing behavior, and I believe it's for the better. The old implementation of these checks did not include `HTMLBlock`, for example. There are no test cases in the CommonMark test suite to prove it, but I believe the new implementation is closer to the definition of "[Paragraph continuation text](https://spec.commonmark.org/0.30/#paragraph-continuation-text)" in the CommonMark spec.

Up for discussion: as it says in the issue report (#166), making `Table` interrupt paragraphs is a change of behavior, and maybe it should be a setting. If so, I'd propose to add the setting to the `Table` class, rather than to make it a renderer parameter, because this is a parsing option and it has nothing to do with the rendering.