### PR TITLE
Add line numbers on all block tokens during parsing (#144)

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -88,7 +88,7 @@ class BlockToken(token.Token):
           of the current token. Every subclass of BlockToken must define a
           start function (see block_tokenizer.tokenize).
 
-        * BlockToken.read takes the rest of the lines in the ducment as an
+        * BlockToken.read takes the rest of the lines in the document as an
           iterator (including the start line), and consumes all the lines
           that should be read into this token.
 
@@ -236,6 +236,7 @@ class Quote(BlockToken):
         if len(line) > 0 and line[0] == ' ':
             line = line[1:]
         line_buffer = [line]
+        start_line = lines.line_number()
 
         # set booleans
         in_code_fence = CodeFence.start(line)
@@ -271,7 +272,7 @@ class Quote(BlockToken):
 
         # parse child block tokens
         Paragraph.parse_setext = False
-        parse_buffer = tokenizer.tokenize_block(line_buffer, _token_types)
+        parse_buffer = tokenizer.tokenize_block(line_buffer, _token_types, start_line=start_line)
         Paragraph.parse_setext = True
         return parse_buffer
 
@@ -603,6 +604,7 @@ class ListItem(BlockToken):
 
         # first line
         line = next(lines)
+        start_line = lines.line_number()
         next_line = lines.peek()
         indentation, prepend, leader, content = prev_marker if prev_marker else cls.parse_marker(line)
         if content.strip() == '':
@@ -663,7 +665,7 @@ class ListItem(BlockToken):
 
         # block-level tokens are parsed here, so that footnotes can be
         # recognized before span-level parsing.
-        parse_buffer = tokenizer.tokenize_block(line_buffer, _token_types)
+        parse_buffer = tokenizer.tokenize_block(line_buffer, _token_types, start_line=start_line)
         return (parse_buffer, indentation, prepend, leader), next_marker
 
 

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -543,7 +543,8 @@ class ListItem(BlockToken):
     pattern = re.compile(r'( {0,3})(\d{0,9}[.)]|[+\-*])($|\s+)')
     continuation_pattern = re.compile(r'([ \t]*)(\S.*\n|\n)')
 
-    def __init__(self, parse_buffer, indentation, prepend, leader):
+    def __init__(self, parse_buffer, indentation, prepend, leader, line_number=None):
+        self.line_number = line_number
         self.leader = leader
         self.indentation = indentation
         self.prepend = prepend
@@ -622,7 +623,7 @@ class ListItem(BlockToken):
                 parse_buffer = tokenizer.ParseBuffer()
                 parse_buffer.loose = True
                 next_marker = cls.parse_marker(next_line) if next_line is not None else None
-                return (parse_buffer, indentation, prepend, leader), next_marker
+                return (parse_buffer, indentation, prepend, leader, start_line), next_marker
         else:
             line_buffer.append(content)
 
@@ -667,7 +668,7 @@ class ListItem(BlockToken):
         # block-level tokens are parsed here, so that footnotes can be
         # recognized before span-level parsing.
         parse_buffer = tokenizer.tokenize_block(line_buffer, _token_types, start_line=start_line)
-        return (parse_buffer, indentation, prepend, leader), next_marker
+        return (parse_buffer, indentation, prepend, leader, start_line), next_marker
 
 
 class Table(BlockToken):

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -109,6 +109,8 @@ class BlockToken(token.Token):
         children (list): inner tokens.
         line_number (int): starting line (1-based).
     """
+    repr_attributes = ("line_number",)
+
     def __init__(self, lines, tokenize_func):
         self.children = tokenize_func(lines)
 
@@ -139,6 +141,7 @@ class Document(BlockToken):
             lines = lines.splitlines(keepends=True)
         lines = [line if line.endswith('\n') else '{}\n'.format(line) for line in lines]
         self.footnotes = {}
+        self.line_number = 1
         token._root_node = self
         self.children = tokenize(lines)
         token._root_node = None
@@ -152,7 +155,7 @@ class Heading(BlockToken):
     Attributes:
         level (int): heading level.
     """
-    repr_attributes = ("level",)
+    repr_attributes = BlockToken.repr_attributes + ("level",)
     pattern = re.compile(r' {0,3}(#{1,6})(?:\n|\s+?(.*?)(\n|\s+?#+\s*?$))')
     level = 0
     content = ''
@@ -193,7 +196,7 @@ class SetextHeading(BlockToken):
     Attributes:
         level (int): heading level.
     """
-    repr_attributes = ("level",)
+    repr_attributes = BlockToken.repr_attributes + ("level",)
 
     def __init__(self, lines):
         self.underline = lines.pop().rstrip()
@@ -352,7 +355,7 @@ class BlockCode(BlockToken):
     Attributes:
         language (str): always the empty string.
     """
-    repr_attributes = ("language",)
+    repr_attributes = BlockToken.repr_attributes + ("language",)
     def __init__(self, lines):
         self.language = ''
         self.children = (span_token.RawText(''.join(lines).strip('\n')+'\n'),)
@@ -408,7 +411,7 @@ class CodeFence(BlockToken):
     Attributes:
         language (str): language of code block (default to empty).
     """
-    repr_attributes = ("language",)
+    repr_attributes = BlockToken.repr_attributes + ("language",)
     pattern = re.compile(r'( {0,3})(`{3,}|~{3,})( *(\S*)[^\n]*)')
     _open_info = None
 
@@ -468,7 +471,7 @@ class List(BlockToken):
         loose (bool): whether the list is loose.
         start (NoneType or int): None if unordered, starting number if ordered.
     """
-    repr_attributes = ("loose", "start")
+    repr_attributes = BlockToken.repr_attributes + ("loose", "start")
     pattern = re.compile(r' {0,3}(?:\d{0,9}[.)]|[+\-*])(?:[ \t]*$|[ \t]+)')
     def __init__(self, matches):
         self.children = [ListItem(*match) for match in matches]
@@ -539,7 +542,7 @@ class ListItem(BlockToken):
                        for continuation lines.
         loose (bool): whether the list is loose.
     """
-    repr_attributes = ("leader", "indentation", "prepend", "loose")
+    repr_attributes = BlockToken.repr_attributes + ("leader", "indentation", "prepend", "loose")
     pattern = re.compile(r'( {0,3})(\d{0,9}[.)]|[+\-*])($|\s+)')
     continuation_pattern = re.compile(r'([ \t]*)(\S.*\n|\n)')
 
@@ -684,7 +687,7 @@ class Table(BlockToken):
         header: header row (TableRow).
         column_align (list): align options for each column (default to [None]).
     """
-    repr_attributes = ("column_align",)
+    repr_attributes = BlockToken.repr_attributes + ("column_align",)
     interrupt_paragraph = True
 
     def __init__(self, match):
@@ -760,7 +763,7 @@ class TableRow(BlockToken):
     Attributes:
         row_align (list): align options for each column (default to [None]).
     """
-    repr_attributes = ("row_align",)
+    repr_attributes = BlockToken.repr_attributes + ("row_align",)
     # Note: Python regex requires fixed-length look-behind,
     # so we cannot use a more precise alternative: r"(?<!\\(?:\\\\)*)(\|)"
     split_pattern = re.compile(r"(?<!\\)\|")
@@ -784,7 +787,7 @@ class TableCell(BlockToken):
     Attributes:
         align (bool): align option for current cell (default to None).
     """
-    repr_attributes = ("align",)
+    repr_attributes = BlockToken.repr_attributes + ("align",)
     def __init__(self, content, align=None, line_number=None):
         self.align = align
         self.line_number = line_number

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -79,9 +79,10 @@ def tokenize_block(iterable, token_types, start_line=1):
     while line is not None:
         for token_type in token_types:
             if token_type.start(line):
+                line_number = lines.line_number() + 1
                 result = token_type.read(lines)
                 if result is not None:
-                    parse_buffer.append((token_type, result))
+                    parse_buffer.append((token_type, result, line_number))
                     break
         else:  # unmatched newlines
             next(lines)
@@ -99,9 +100,10 @@ def make_tokens(parse_buffer):
     and span-level parsing is started here.
     """
     tokens = []
-    for token_type, result in parse_buffer:
+    for token_type, result, line_number in parse_buffer:
         token = token_type(result)
         if token is not None:
+            token.line_number = line_number
             tokens.append(token)
     return tokens
 

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -68,7 +68,7 @@ def tokenize(iterable, token_types):
 
 def tokenize_block(iterable, token_types, start_line=1):
     """
-    Returns a list of pairs (token_type, read_result).
+    Returns a list of tuples (token_type, read_result, line_number).
 
     Footnotes are parsed here, but span-level parsing has not
     started yet.
@@ -93,8 +93,8 @@ def tokenize_block(iterable, token_types, start_line=1):
 
 def make_tokens(parse_buffer):
     """
-    Takes a list of pairs (token_type, read_result) and
-    applies token_type(read_result).
+    Takes a list of tuples (token_type, read_result, line_number),
+    applies token_type(read_result), and sets the line_number attribute.
 
     Footnotes are already parsed before this point,
     and span-level parsing is started here.

--- a/mistletoe/block_tokenizer.py
+++ b/mistletoe/block_tokenizer.py
@@ -4,8 +4,9 @@ Block-level tokenizer for mistletoe.
 
 
 class FileWrapper:
-    def __init__(self, lines):
+    def __init__(self, lines, start_line=1):
         self.lines = lines if isinstance(lines, list) else list(lines)
+        self.start_line = start_line
         self._index = -1
         self._anchor = 0
 
@@ -47,6 +48,9 @@ class FileWrapper:
         if self._index != -1:
             self._index -= 1
 
+    def line_number(self):
+        return self.start_line + self._index
+
 
 def tokenize(iterable, token_types):
     """
@@ -62,14 +66,14 @@ def tokenize(iterable, token_types):
     return make_tokens(tokenize_block(iterable, token_types))
 
 
-def tokenize_block(iterable, token_types):
+def tokenize_block(iterable, token_types, start_line=1):
     """
     Returns a list of pairs (token_type, read_result).
 
     Footnotes are parsed here, but span-level parsing has not
     started yet.
     """
-    lines = FileWrapper(iterable)
+    lines = FileWrapper(iterable, start_line=start_line)
     parse_buffer = ParseBuffer()
     line = lines.peek()
     while line is not None:

--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -51,7 +51,7 @@ class LinkReferenceDefinition(span_token.SpanToken):
 class LinkReferenceDefinitionBlock(block_token.Footnote):
     """
     A sequence of link reference definitions.
-    This is a container block token. Its children are link reference definition tokens.
+    This is a leaf block token. Its children are link reference definition tokens.
 
     This class inherits from `Footnote` and modifies the behavior of the constructor,
     to keep the tokens in the AST.

--- a/test/samples/line_numbers.md
+++ b/test/samples/line_numbers.md
@@ -1,0 +1,37 @@
+# Test document for line numbers
+
+See test_line_numbers.py.
+Every number written as inline code should match the line number of its nearest
+parent block token. Same with titles of link reference definitions.
+
+## Heading `7`
+
+Basic paragraph.
+
+> Block quote (with a paragraph inside)
+> It's the start line that counts! `11`
+> * a list inside the quote
+> * with two items `14`
+>
+> Still the same block quote, but another paragraph `16`
+
+1. List item `18`
+2. Nested list
+   * item
+   * another item `21`
+3. List item with a nested `22`
+   > block quote `23`
+
+| Table `25` | Columns |
+| ---------- | ------- |
+| ?          | ! `27`  |
+
+Paragraph with <p>inline HTML</p> `29`
+
+Setext
+heading `31`
+------------
+
+Paragraph with [ref] to a link reference definition.
+
+[ref]: /url (37)

--- a/test/test_ast_renderer.py
+++ b/test/test_ast_renderer.py
@@ -4,19 +4,27 @@ from mistletoe import Document, ast_renderer
 class TestAstRenderer(unittest.TestCase):
     def test(self):
         self.maxDiff = None
-        d = Document(['# heading 1\n', '\n', 'hello\n', 'world\n'])
+        d = Document([
+            '# heading 1\n',
+            '\n',
+            'hello\n',
+            'world\n',
+        ])
         output = ast_renderer.get_ast(d)
         expected = {'type': 'Document',
                   'footnotes': {},
+                  'line_number': 1,
                   'children': [{
                       'type': 'Heading',
                       'level': 1,
+                      'line_number': 1,
                       'children': [{
                           'type': 'RawText',
                           'content': 'heading 1'
                       }]
                   }, {
                       'type': 'Paragraph',
+                      'line_number': 3,
                       'children': [{
                           'type': 'RawText',
                           'content': 'hello'
@@ -33,13 +41,17 @@ class TestAstRenderer(unittest.TestCase):
 
     def test_footnotes(self):
         self.maxDiff = None
-        d = Document(['[bar][baz]\n',
-                      '\n',
-                      '[baz]: spam\n'])
+        d = Document([
+            '[bar][baz]\n',
+            '\n',
+            '[baz]: spam\n',
+        ])
         expected = {'type': 'Document',
                   'footnotes': {'baz': ('spam', '')},
+                  'line_number': 1,
                   'children': [{
                       'type': 'Paragraph',
+                      'line_number': 1,
                       'children': [{
                           'type': 'Link',
                           'target': 'spam',
@@ -55,31 +67,34 @@ class TestAstRenderer(unittest.TestCase):
 
     def test_table(self):
         self.maxDiff = None
-        d = Document(
-            [
-                "| A   | B   |\n",
-                "| --- | --- |\n",
-                "| 1   | 2   |\n",
-            ]
-        )
+        d = Document([
+            "| A   | B   |\n",
+            "| --- | --- |\n",
+            "| 1   | 2   |\n",
+        ])
         expected = {
             "type": "Document",
             "footnotes": {},
+            'line_number': 1,
             "children": [{
                 "type": "Table",
                 "column_align": [None, None],
+                'line_number': 1,
                 "header": {
                     "type": "TableRow",
                     "row_align": [None, None],
+                    'line_number': 1,
                     "children": [{
                         "type": "TableCell",
                         "align": None,
+                        'line_number': 1,
                         "children": [{
                             "type": "RawText",
                             "content": "A",
                     }]}, {
                         "type": "TableCell",
                         "align": None,
+                        'line_number': 1,
                         "children": [{
                             "type": "RawText",
                             "content": "B",
@@ -88,15 +103,18 @@ class TestAstRenderer(unittest.TestCase):
                 "children": [{
                     "type": "TableRow",
                     "row_align": [None, None],
+                    'line_number': 3,
                     "children": [{
                         "type": "TableCell",
                         "align": None,
+                        'line_number': 3,
                         "children": [{
                             "type": "RawText",
                             "content": "1",
                     }]}, {
                         "type": "TableCell",
                         "align": None,
+                        'line_number': 3,
                         "children": [{
                             "type": "RawText",
                             "content": "2",

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -390,7 +390,7 @@ class TestTable(unittest.TestCase):
             self.assertTrue(hasattr(token, 'header'))
             self.assertEqual(token.column_align, [None, None, None])
             token.children
-            calls = [call(line, line_number, [None, None, None]) for line_number, line in enumerate(lines, start=1) if line_number != 2]
+            calls = [call(line, [None, None, None], line_number) for line_number, line in enumerate(lines, start=1) if line_number != 2]
             mock.assert_has_calls(calls)
 
     def test_easy_table(self):
@@ -403,7 +403,7 @@ class TestTable(unittest.TestCase):
             self.assertTrue(hasattr(token, 'header'))
             self.assertEqual(token.column_align, [1, None])
             token.children
-            calls = [call(line, line_number, [1, None]) for line_number, line in enumerate(lines, start=1) if line_number != 2]
+            calls = [call(line, [1, None], line_number) for line_number, line in enumerate(lines, start=1) if line_number != 2]
             mock.assert_has_calls(calls)
 
     def test_not_easy_table(self):
@@ -433,43 +433,43 @@ class TestTableRow(unittest.TestCase):
     def test_match(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '| cell 1 | cell 2 |\n'
-            token = block_token.TableRow(line, 10)
+            token = block_token.TableRow(line, line_number=10)
             self.assertEqual(token.row_align, [None])
-            mock.assert_has_calls([call('cell 1', 10, None), call('cell 2', 10, None)])
+            mock.assert_has_calls([call('cell 1', None, 10), call('cell 2', None, 10)])
 
     def test_easy_table_row(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = 'cell 1 | cell 2\n'
-            token = block_token.TableRow(line, 10)
+            token = block_token.TableRow(line, line_number=10)
             self.assertEqual(token.row_align, [None])
-            mock.assert_has_calls([call('cell 1', 10, None), call('cell 2', 10, None)])
+            mock.assert_has_calls([call('cell 1', None, 10), call('cell 2', None, 10)])
 
     def test_short_row(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '| cell 1 |\n'
-            token = block_token.TableRow(line, 10, [None, None])
+            token = block_token.TableRow(line, [None, None], 10)
             self.assertEqual(token.row_align, [None, None])
-            mock.assert_has_calls([call('cell 1', 10, None), call('', 10, None)])
+            mock.assert_has_calls([call('cell 1', None, 10), call('', None, 10)])
 
     def test_escaped_pipe_in_cell(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '| pipe: `\\|` | cell 2\n'
-            token = block_token.TableRow(line, 10, [None, None])
+            token = block_token.TableRow(line, line_number=10, row_align=[None, None])
             self.assertEqual(token.row_align, [None, None])
-            mock.assert_has_calls([call('pipe: `|`', 10, None), call('cell 2', 10, None)])
+            mock.assert_has_calls([call('pipe: `|`', None, 10), call('cell 2', None, 10)])
     
     @unittest.skip('Even GitHub fails in here, workaround: always put a space before `|`')
     def test_not_really_escaped_pipe_in_cell(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '|ending with a \\\\|cell 2\n'
-            token = block_token.TableRow(line, 10, [None, None])
+            token = block_token.TableRow(line, [None, None], 10)
             self.assertEqual(token.row_align, [None, None])
-            mock.assert_has_calls([call('ending with a \\\\', 10, None), call('cell 2', 10, None)])
+            mock.assert_has_calls([call('ending with a \\\\', None, 10), call('cell 2', None, 10)])
 
 
 class TestTableCell(TestToken):
     def test_match(self):
-        token = block_token.TableCell('cell 2', 13)
+        token = block_token.TableCell('cell 2', line_number=13)
         self._test_token(token, 'cell 2', line_number=13, align=None)
 
 

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -390,7 +390,7 @@ class TestTable(unittest.TestCase):
             self.assertTrue(hasattr(token, 'header'))
             self.assertEqual(token.column_align, [None, None, None])
             token.children
-            calls = [call(line, [None, None, None]) for line in lines[:1]+lines[2:]]
+            calls = [call(line, line_number, [None, None, None]) for line_number, line in enumerate(lines, start=1) if line_number != 2]
             mock.assert_has_calls(calls)
 
     def test_easy_table(self):
@@ -403,7 +403,7 @@ class TestTable(unittest.TestCase):
             self.assertTrue(hasattr(token, 'header'))
             self.assertEqual(token.column_align, [1, None])
             token.children
-            calls = [call(line, [1, None]) for line in lines[:1] + lines[2:]]
+            calls = [call(line, line_number, [1, None]) for line_number, line in enumerate(lines, start=1) if line_number != 2]
             mock.assert_has_calls(calls)
 
     def test_not_easy_table(self):
@@ -433,44 +433,44 @@ class TestTableRow(unittest.TestCase):
     def test_match(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '| cell 1 | cell 2 |\n'
-            token = block_token.TableRow(line)
+            token = block_token.TableRow(line, 10)
             self.assertEqual(token.row_align, [None])
-            mock.assert_has_calls([call('cell 1', None), call('cell 2', None)])
+            mock.assert_has_calls([call('cell 1', 10, None), call('cell 2', 10, None)])
 
     def test_easy_table_row(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = 'cell 1 | cell 2\n'
-            token = block_token.TableRow(line)
+            token = block_token.TableRow(line, 10)
             self.assertEqual(token.row_align, [None])
-            mock.assert_has_calls([call('cell 1', None), call('cell 2', None)])
+            mock.assert_has_calls([call('cell 1', 10, None), call('cell 2', 10, None)])
 
     def test_short_row(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '| cell 1 |\n'
-            token = block_token.TableRow(line, [None, None])
+            token = block_token.TableRow(line, 10, [None, None])
             self.assertEqual(token.row_align, [None, None])
-            mock.assert_has_calls([call('cell 1', None), call('', None)])
+            mock.assert_has_calls([call('cell 1', 10, None), call('', 10, None)])
 
     def test_escaped_pipe_in_cell(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '| pipe: `\\|` | cell 2\n'
-            token = block_token.TableRow(line, [None, None])
+            token = block_token.TableRow(line, 10, [None, None])
             self.assertEqual(token.row_align, [None, None])
-            mock.assert_has_calls([call('pipe: `|`', None), call('cell 2', None)])
+            mock.assert_has_calls([call('pipe: `|`', 10, None), call('cell 2', 10, None)])
     
     @unittest.skip('Even GitHub fails in here, workaround: always put a space before `|`')
     def test_not_really_escaped_pipe_in_cell(self):
         with patch('mistletoe.block_token.TableCell') as mock:
             line = '|ending with a \\\\|cell 2\n'
-            token = block_token.TableRow(line, [None, None])
+            token = block_token.TableRow(line, 10, [None, None])
             self.assertEqual(token.row_align, [None, None])
-            mock.assert_has_calls([call('ending with a \\\\', None), call('cell 2', None)])
+            mock.assert_has_calls([call('ending with a \\\\', 10, None), call('cell 2', 10, None)])
 
 
 class TestTableCell(TestToken):
     def test_match(self):
-        token = block_token.TableCell('cell 2')
-        self._test_token(token, 'cell 2', align=None)
+        token = block_token.TableCell('cell 2', 13)
+        self._test_token(token, 'cell 2', line_number=13, align=None)
 
 
 class TestFootnote(unittest.TestCase):

--- a/test/test_line_numbers.py
+++ b/test/test_line_numbers.py
@@ -1,0 +1,57 @@
+import unittest
+
+import mistletoe.block_token as block_token
+import mistletoe.span_token as span_token
+from mistletoe.markdown_renderer import (
+    LinkReferenceDefinition,
+    LinkReferenceDefinitionBlock,
+)
+
+
+class TestLineNumbers(unittest.TestCase):
+    def setUp(self) -> None:
+        block_token.add_token(block_token.HTMLBlock)
+        span_token.add_token(span_token.HTMLSpan)
+        block_token.remove_token(block_token.Footnote)
+        block_token.add_token(LinkReferenceDefinitionBlock)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        span_token.reset_tokens()
+        block_token.reset_tokens()
+        return super().tearDown()
+
+    def test_main(self):
+        # see line_numbers.md for a description of how the test works.
+        NUMBER_OF_LINE_NUMBERS_TO_BE_CHECKED = 13
+        with open("test/samples/line_numbers.md", "r") as fin:
+            document = block_token.Document(fin)
+        count = self.check_line_numbers(document)
+        self.assertEqual(count, NUMBER_OF_LINE_NUMBERS_TO_BE_CHECKED)
+
+    def check_line_numbers(self, token: block_token.BlockToken):
+        """Check the line number on the given block token and its children, if possible."""
+        count = 0
+        line_number = self.get_expected_line_number(token)
+        if line_number:
+            self.assertEqual(token.line_number, line_number)
+            count += 1
+
+        if isinstance(token, block_token.Table):
+            count += self.check_line_numbers(token.header)
+
+        for child in token.children:
+            if isinstance(child, block_token.BlockToken):
+                count += self.check_line_numbers(child)
+
+        return count
+
+    def get_expected_line_number(self, token: block_token.BlockToken):
+        # the expected line number, if it exists, should be wrapped in an inline
+        # code token and be an immediate child of the token.
+        # or it could be the title of a link reference definition.
+        for child in token.children:
+            if isinstance(child, span_token.InlineCode):
+                return int(child.children[0].content)
+            if isinstance(child, LinkReferenceDefinition):
+                return int(child.title)

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -14,53 +14,53 @@ class TestRepr(unittest.TestCase):
 
     def test_document(self):
         doc = Document("# Foo")
-        self._check_repr_matches(doc, "block_token.Document with 1 child")
+        self._check_repr_matches(doc, "block_token.Document with 1 child line_number=1")
 
     def test_heading(self):
         doc = Document("# Foo")
-        self._check_repr_matches(doc.children[0], "block_token.Heading with 1 child level=1")
+        self._check_repr_matches(doc.children[0], "block_token.Heading with 1 child line_number=1 level=1")
         self._check_repr_matches(doc.children[0].children[0], "span_token.RawText content='Foo'")
 
     def test_subheading(self):
         doc = Document("# Foo\n## Bar")
-        self._check_repr_matches(doc.children[1], "block_token.Heading with 1 child level=2")
+        self._check_repr_matches(doc.children[1], "block_token.Heading with 1 child line_number=2 level=2")
         self._check_repr_matches(doc.children[1].children[0], "span_token.RawText content='Bar'")
 
     def test_quote(self):
         doc = Document("> Foo")
-        self._check_repr_matches(doc.children[0], "block_token.Quote with 1 child")
+        self._check_repr_matches(doc.children[0], "block_token.Quote with 1 child line_number=1")
 
     def test_paragraph(self):
         doc = Document("Foo")
-        self._check_repr_matches(doc.children[0], "block_token.Paragraph with 1 child")
+        self._check_repr_matches(doc.children[0], "block_token.Paragraph with 1 child line_number=1")
 
     def test_blockcode(self):
         doc = Document("Foo\n\n\tBar\n\nBaz")
-        self._check_repr_matches(doc.children[1], "block_token.BlockCode with 1 child language=''")
+        self._check_repr_matches(doc.children[1], "block_token.BlockCode with 1 child line_number=3 language=''")
 
     def test_codefence(self):
         doc = Document("""```python\nprint("Hello, World!"\n```""")
-        self._check_repr_matches(doc.children[0], "block_token.CodeFence with 1 child language='python'")
+        self._check_repr_matches(doc.children[0], "block_token.CodeFence with 1 child line_number=1 language='python'")
 
     def test_unordered_list(self):
         doc = Document("* Foo\n* Bar\n* Baz")
-        self._check_repr_matches(doc.children[0], "block_token.List with 3 children loose=False start=None")
-        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='*' indentation=0 prepend=2 loose=False")
+        self._check_repr_matches(doc.children[0], "block_token.List with 3 children line_number=1 loose=False start=None")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child line_number=1 leader='*' indentation=0 prepend=2 loose=False")
 
     def test_ordered_list(self):
         doc = Document("1. Foo\n2. Bar\n3. Baz")
-        self._check_repr_matches(doc.children[0], "block_token.List with 3 children loose=False start=1")
-        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='1.' indentation=0 prepend=3 loose=False")
+        self._check_repr_matches(doc.children[0], "block_token.List with 3 children line_number=1 loose=False start=1")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child line_number=1 leader='1.' indentation=0 prepend=3 loose=False")
 
     def test_table(self):
         doc = Document("| Foo | Bar | Baz |\n|:--- |:---:| ---:|\n| Foo | Bar | Baz |\n")
-        self._check_repr_matches(doc.children[0], "block_token.Table with 1 child column_align=[None, 0, 1]")
-        self._check_repr_matches(doc.children[0].children[0], "block_token.TableRow with 3 children row_align=[None, 0, 1]")
-        self._check_repr_matches(doc.children[0].children[0].children[0], "block_token.TableCell with 1 child align=None")
+        self._check_repr_matches(doc.children[0], "block_token.Table with 1 child line_number=1 column_align=[None, 0, 1]")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.TableRow with 3 children line_number=3 row_align=[None, 0, 1]")
+        self._check_repr_matches(doc.children[0].children[0].children[0], "block_token.TableCell with 1 child line_number=3 align=None")
 
     def test_thematicbreak(self):
         doc = Document("Foo\n\n---\n\nBar\n")
-        self._check_repr_matches(doc.children[1], "block_token.ThematicBreak")
+        self._check_repr_matches(doc.children[1], "block_token.ThematicBreak line_number=3")
 
     # No test for ``Footnote``
 
@@ -70,7 +70,7 @@ class TestRepr(unittest.TestCase):
             doc = Document("<pre>\nFoo\n</pre>\n")
         finally:
             block_token.reset_tokens()
-        self._check_repr_matches(doc.children[0], "block_token.HtmlBlock with 1 child")
+        self._check_repr_matches(doc.children[0], "block_token.HtmlBlock with 1 child line_number=1")
         self._check_repr_matches(doc.children[0].children[0], "span_token.RawText content='<pre>\\nFoo\\n</pre>'")
 
     # Span tokens


### PR DESCRIPTION
This is a partial solution for #144 which records line numbers on all _block_ tokens. The _span_ tokens are still left unlabeled, but at least it's a starting point, and I think the functionality added here is useful by itself.

Open question: should the `line_number` be a added to `repr_attributes`, so that it gets included in the output from `ASTRenderer`?