### PR TITLE
refactor: use strict PascalCase for class names (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ with open('dev-guide.md', 'r') as fin:
 ```
 
 Finally, here's how you would manually specify extra tokens via a renderer.
-In the following example, we use `HTMLRenderer` to render
-the AST. The renderer itself adds `HTMLBlock` and `HTMLSpan` tokens to the parsing
+In the following example, we use `HtmlRenderer` to render
+the AST. The renderer itself adds `HtmlBlock` and `HtmlSpan` tokens to the parsing
 process. The result should be equal to the output obtained from
 the first example above.
 
 ```python
-from mistletoe import Document, HTMLRenderer
+from mistletoe import Document, HtmlRenderer
 
 with open('foo.md', 'r') as fin:
-    with HTMLRenderer() as renderer:     # or: `with HTMLRenderer(AnotherToken1, AnotherToken2) as renderer:`
+    with HtmlRenderer() as renderer:     # or: `with HtmlRenderer(AnotherToken1, AnotherToken2) as renderer:`
         doc = Document(fin)              # parse the lines into AST
         rendered = renderer.render(doc)  # render the AST
         # internal lists of tokens to be parsed are automatically reset when exiting this `with` block
@@ -169,7 +169,7 @@ mistletoe foo.md --renderer mistletoe.latex_renderer.LaTeXRenderer
 and similarly for a renderer in the contrib package:
 
 ```sh
-mistletoe foo.md --renderer mistletoe.contrib.jira_renderer.JIRARenderer
+mistletoe foo.md --renderer mistletoe.contrib.jira_renderer.JiraRenderer
 ```
 
 

--- a/dev-guide.md
+++ b/dev-guide.md
@@ -11,11 +11,11 @@ as an "abstract syntax tree" (AST), stored in an instance of `Document`.
 This object contains a hierarchy of
 all the various tokens which were recognized during the parsing process.
 
-In order to see what exactly gets parsed, one can simply use the `ASTRenderer`
+In order to see what exactly gets parsed, one can simply use the `AstRenderer`
 on a given markdown input, for example:
 
 ```sh
-mistletoe text.md --renderer mistletoe.ast_renderer.ASTRenderer
+mistletoe text.md --renderer mistletoe.ast_renderer.AstRenderer
 ```
 
 Say that the input file contains for example:
@@ -166,7 +166,7 @@ There you go: a new token in 5 lines of code.
 ### Side note about precedence
 
 Normally there is no need to override the `precedence` value of a custom token.
-The default value is the same as `InlineCode`, `AutoLink` and `HTMLSpan`,
+The default value is the same as `InlineCode`, `AutoLink` and `HtmlSpan`,
 which means that whichever token comes first will be parsed. In our case:
 
 ```markdown
@@ -193,9 +193,9 @@ of most of them for you. Simply passing your custom token class to
 `super().__init__()` does the trick:
 
 ```python
-from mistletoe.html_renderer import HTMLRenderer
+from mistletoe.html_renderer import HtmlRenderer
 
-class GithubWikiRenderer(HTMLRenderer):
+class GithubWikiRenderer(HtmlRenderer):
     def __init__(self):
         super().__init__(GithubWiki)
 ```
@@ -212,9 +212,9 @@ def render_github_wiki(self, token):
 Cleaning up, we have our new renderer class:
 
 ```python
-from mistletoe.html_renderer import HTMLRenderer, escape_url
+from mistletoe.html_renderer import HtmlRenderer, escape_url
 
-class GithubWikiRenderer(HTMLRenderer):
+class GithubWikiRenderer(HtmlRenderer):
     def __init__(self):
         super().__init__(GithubWiki)
 

--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,4 +1,4 @@
-from mistletoe import Document, HTMLRenderer, __version__
+from mistletoe import Document, HtmlRenderer, __version__
 
 INCLUDE = {'README.md': 'index.html',
            'CONTRIBUTING.md': 'contributing.html'}
@@ -19,7 +19,7 @@ METADATA = """
 """
 
 
-class DocRenderer(HTMLRenderer):
+class DocRenderer(HtmlRenderer):
     def render_link(self, token):
         return super().render_link(self._replace_link(token))
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,14 +81,14 @@ with open(&#x27;foo.md&#x27;, &#x27;r&#x27;) as fin:
     rendered = mistletoe.markdown(fin, LaTeXRenderer)
 </code></pre>
 <p>Finally, here&#x27;s how you would manually specify extra tokens and a renderer
-for mistletoe. In the following example, we use <code>HTMLRenderer</code> to render
-the AST, which adds <code>HTMLBlock</code> and <code>HTMLSpan</code> to the normal parsing
+for mistletoe. In the following example, we use <code>HtmlRenderer</code> to render
+the AST, which adds <code>HtmlBlock</code> and <code>HtmlSpan</code> to the normal parsing
 process.
 </p>
-<pre><code class="lang-python">from mistletoe import Document, HTMLRenderer
+<pre><code class="lang-python">from mistletoe import Document, HtmlRenderer
 
 with open(&#x27;foo.md&#x27;, &#x27;r&#x27;) as fin:
-    with HTMLRenderer() as renderer:
+    with HtmlRenderer() as renderer:
         rendered = renderer.render(Document(fin))
 </code></pre>
 <h3>From the command-line</h3>
@@ -209,9 +209,9 @@ of nasty implementation details. Fortunately, mistletoe takes care
 of most of them for you. Simply pass your custom token class to 
 <code>super().__init__()</code> does the trick:
 </p>
-<pre><code class="lang-python">from mistletoe.html_renderer import HTMLRenderer
+<pre><code class="lang-python">from mistletoe.html_renderer import HtmlRenderer
 
-class GithubWikiRenderer(HTMLRenderer):
+class GithubWikiRenderer(HtmlRenderer):
     def __init__(self):
         super().__init__(GithubWiki)
 </code></pre>
@@ -225,9 +225,9 @@ class GithubWikiRenderer(HTMLRenderer):
 </code></pre>
 <p>Cleaning up, we have our new renderer class:
 </p>
-<pre><code class="lang-python">from mistletoe.html_renderer import HTMLRenderer, escape_url
+<pre><code class="lang-python">from mistletoe.html_renderer import HtmlRenderer, escape_url
 
-class GithubWikiRenderer(HTMLRenderer):
+class GithubWikiRenderer(HtmlRenderer):
     def __init__(self):
         super().__init__(GithubWiki)
 

--- a/mistletoe/__init__.py
+++ b/mistletoe/__init__.py
@@ -7,12 +7,12 @@ __all__ = ['html_renderer', 'ast_renderer', 'block_token', 'block_tokenizer',
            'span_token', 'span_tokenizer']
 
 from mistletoe.block_token import Document
-from mistletoe.html_renderer import HTMLRenderer
+from mistletoe.html_renderer import HtmlRenderer
 
-def markdown(iterable, renderer=HTMLRenderer):
+def markdown(iterable, renderer=HtmlRenderer):
     """
     Converts markdown input to the output supported by the given renderer.
-    If no renderer is supplied, ``HTMLRenderer`` is used.
+    If no renderer is supplied, ``HtmlRenderer`` is used.
 
     Note that extra token types supported by the given renderer
     are automatically (and temporarily) added to the parsing process.

--- a/mistletoe/ast_renderer.py
+++ b/mistletoe/ast_renderer.py
@@ -5,7 +5,7 @@ Abstract syntax tree renderer for mistletoe.
 import json
 from mistletoe.base_renderer import BaseRenderer
 
-class ASTRenderer(BaseRenderer):
+class AstRenderer(BaseRenderer):
     def render(self, token):
         """
         Returns the string representation of the AST.
@@ -43,3 +43,9 @@ def get_ast(token):
     if 'children' in vars(token):
         node['children'] = [get_ast(child) for child in token.children]
     return node
+
+
+ASTRenderer = AstRenderer
+"""
+Deprecated name of the `AstRenderer` class.
+"""

--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -997,7 +997,7 @@ class ThematicBreak(BlockToken):
         return [next(lines)]
 
 
-class HTMLBlock(BlockToken):
+class HtmlBlock(BlockToken):
     """
     Block-level HTML token.
     This is a leaf block token with a single child of type span_token.RawText,
@@ -1074,6 +1074,12 @@ class HTMLBlock(BlockToken):
                 lines.backstep()
                 break
         return line_buffer
+
+
+HTMLBlock = HtmlBlock
+"""
+Deprecated name of the `HtmlBlock` class.
+"""
 
 
 _token_types = []

--- a/mistletoe/cli.py
+++ b/mistletoe/cli.py
@@ -56,7 +56,7 @@ def interactive(renderer):
 def parse(args):
     parser = ArgumentParser()
     parser.add_argument('-r', '--renderer', type=_import,
-                        default='mistletoe.HTMLRenderer',
+                        default='mistletoe.HtmlRenderer',
                         help='specify an importable renderer class')
     parser.add_argument('-v', '--version', action='version', version=version_str)
     parser.add_argument('filenames', nargs='*',
@@ -88,6 +88,6 @@ def _import_readline():
 def _print_heading(renderer):
     print('{} (interactive)'.format(version_str))
     print('Type Ctrl-D to complete input, or Ctrl-C to exit.')
-    if renderer is not mistletoe.HTMLRenderer:
+    if renderer is not mistletoe.HtmlRenderer:
         print('Using renderer: {}'.format(renderer.__name__))
 

--- a/mistletoe/contrib/github_wiki.py
+++ b/mistletoe/contrib/github_wiki.py
@@ -4,7 +4,7 @@ GitHub Wiki support for mistletoe.
 
 import re
 from mistletoe.span_token import SpanToken
-from mistletoe.html_renderer import HTMLRenderer
+from mistletoe.html_renderer import HtmlRenderer
 
 
 __all__ = ['GithubWiki', 'GithubWikiRenderer']
@@ -17,7 +17,7 @@ class GithubWiki(SpanToken):
         self.target = match.group(2)
 
 
-class GithubWikiRenderer(HTMLRenderer):
+class GithubWikiRenderer(HtmlRenderer):
     def __init__(self, **kwargs):
         """
         Args:

--- a/mistletoe/contrib/jira_renderer.py
+++ b/mistletoe/contrib/jira_renderer.py
@@ -26,7 +26,7 @@ from mistletoe import block_token, span_token
 from mistletoe.base_renderer import BaseRenderer
 import re
 
-class JIRARenderer(BaseRenderer):
+class JiraRenderer(BaseRenderer):
     """
     JIRA renderer class.
 
@@ -39,7 +39,7 @@ class JIRARenderer(BaseRenderer):
         """
         self.listTokens = []
         self.lastChildOfQuotes = []
-        super().__init__(*chain([block_token.HTMLBlock, span_token.HTMLSpan], extras))
+        super().__init__(*chain([block_token.HtmlBlock, span_token.HtmlSpan], extras))
 
     def render_strong(self, token):
         template = '*{}*'
@@ -233,4 +233,8 @@ def escape_url(raw):
     from urllib.parse import quote
     return quote(raw, safe='/#:()*?=%@+,&;')
 
-    
+
+JIRARenderer = JiraRenderer
+"""
+Deprecated name of the `JiraRenderer` class.
+"""

--- a/mistletoe/contrib/mathjax.py
+++ b/mistletoe/contrib/mathjax.py
@@ -2,10 +2,10 @@
 Provides MathJax support for rendering Markdown with LaTeX to html.
 """
 
-from mistletoe.html_renderer import HTMLRenderer
+from mistletoe.html_renderer import HtmlRenderer
 from mistletoe.latex_renderer import LaTeXRenderer
 
-class MathJaxRenderer(HTMLRenderer, LaTeXRenderer):
+class MathJaxRenderer(HtmlRenderer, LaTeXRenderer):
     def __init__(self, **kwargs):
         """
         Args:

--- a/mistletoe/contrib/md2jira.py
+++ b/mistletoe/contrib/md2jira.py
@@ -26,7 +26,7 @@ import os
 import sys
 import getopt
 import mistletoe
-from mistletoe.contrib.jira_renderer import JIRARenderer
+from mistletoe.contrib.jira_renderer import JiraRenderer
 
 usageString = '%s <markdownfile>' % os.path.basename(sys.argv[0])
 helpString = """
@@ -59,11 +59,11 @@ class CommandLineParser:
             sys.stderr.write(usageString + '\n')
             sys.exit(1)
 
-        app = MarkdownToJIRA()
+        app = MarkdownToJira()
         app.run(optlist, args)
 
 
-class MarkdownToJIRA:
+class MarkdownToJira:
     def __init__(self):
         self.version = "1.0.2"
         self.options = {}
@@ -89,13 +89,19 @@ class MarkdownToJIRA:
             sys.exit(1)
 
         with open(args[0], 'r', encoding='utf-8') if len(args) == 1 else sys.stdin as infile:
-            rendered = mistletoe.markdown(infile, JIRARenderer)
+            rendered = mistletoe.markdown(infile, JiraRenderer)
 
         if self.options['output'] == '-':
             sys.stdout.write(rendered)
         else:
             with open(self.options['output'], 'w', encoding='utf-8') as outfile:
                 outfile.write(rendered)
+
+
+MarkdownToJIRA = MarkdownToJira
+"""
+Deprecated name of the `MarkdownToJira` class.
+"""
 
 
 if __name__ == '__main__':

--- a/mistletoe/contrib/pygments_renderer.py
+++ b/mistletoe/contrib/pygments_renderer.py
@@ -1,4 +1,4 @@
-from mistletoe import HTMLRenderer
+from mistletoe import HtmlRenderer
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import get_lexer_by_name as get_lexer, guess_lexer
@@ -6,7 +6,7 @@ from pygments.styles import get_style_by_name as get_style
 from pygments.util import ClassNotFound
 
 
-class PygmentsRenderer(HTMLRenderer):
+class PygmentsRenderer(HtmlRenderer):
     formatter = HtmlFormatter()
     formatter.noclasses = True
 

--- a/mistletoe/contrib/toc_renderer.py
+++ b/mistletoe/contrib/toc_renderer.py
@@ -5,12 +5,12 @@ See `if __name__ == '__main__'` section for sample usage.
 """
 
 import re
-from mistletoe.html_renderer import HTMLRenderer
+from mistletoe.html_renderer import HtmlRenderer
 from mistletoe import block_token
 
-class TOCRenderer(HTMLRenderer):
+class TocRenderer(HtmlRenderer):
     """
-    Extends HTMLRenderer class for table of contents support.
+    Extends HtmlRenderer class for table of contents support.
     """
     def __init__(self, *extras, depth=5, omit_title=True, filter_conds=[], **kwargs):
         """
@@ -68,3 +68,9 @@ class TOCRenderer(HTMLRenderer):
         Helper method; converts rendered heading to plain text.
         """
         return re.sub(r'<.+?>', '', rendered)
+
+
+TOCRenderer = TocRenderer
+"""
+Deprecated name of the `TocRenderer` class.
+"""

--- a/mistletoe/contrib/xwiki20_renderer.py
+++ b/mistletoe/contrib/xwiki20_renderer.py
@@ -17,7 +17,7 @@ class XWiki20Renderer(BaseRenderer):
         self.lastChildOfQuotes = []
         self.firstChildOfListItems = []
 
-        localExtras = [block_token.HTMLBlock, span_token.HTMLSpan, span_token.XWikiBlockMacroStart, span_token.XWikiBlockMacroEnd]
+        localExtras = [block_token.HtmlBlock, span_token.HtmlSpan, span_token.XWikiBlockMacroStart, span_token.XWikiBlockMacroEnd]
         super().__init__(*chain(localExtras, extras))
 
     def render_strong(self, token):
@@ -73,7 +73,7 @@ class XWiki20Renderer(BaseRenderer):
         return '\n' + token.content
     
     def render_html_span(self, token):
-        # XXX: HTMLSpan parses (contains) only individual opening and closing tags
+        # XXX: HtmlSpan parses (contains) only individual opening and closing tags
         # => no easy way to wrap the whole HTML code into {{html}} like this:
         # 
         # template = '{{{{html wiki="true"}}}}{}{{{{/html}}}}'
@@ -162,7 +162,7 @@ class XWiki20Renderer(BaseRenderer):
         
 
     def render_table(self, token):
-        # Copied from JIRARenderer...
+        # Copied from JiraRenderer...
         #
         # This is actually gross and I wonder if there's a better way to do it.
         #

--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -7,12 +7,12 @@ from itertools import chain
 from urllib.parse import quote
 from mistletoe import block_token
 from mistletoe import span_token
-from mistletoe.block_token import HTMLBlock
-from mistletoe.span_token import HTMLSpan
+from mistletoe.block_token import HtmlBlock
+from mistletoe.span_token import HtmlSpan
 from mistletoe.base_renderer import BaseRenderer
 
 
-class HTMLRenderer(BaseRenderer):
+class HtmlRenderer(BaseRenderer):
     """
     HTML renderer class.
 
@@ -30,7 +30,7 @@ class HTMLRenderer(BaseRenderer):
                 constructor.
         """
         self._suppress_ptag_stack = [False]
-        super().__init__(*chain((HTMLBlock, HTMLSpan), extras), **kwargs)
+        super().__init__(*chain((HtmlBlock, HtmlSpan), extras), **kwargs)
         self.html_escape_double_quotes = html_escape_double_quotes
         self.html_escape_single_quotes = html_escape_single_quotes
 
@@ -94,7 +94,7 @@ class HTMLRenderer(BaseRenderer):
         return self.escape_html_text(token.content)
 
     @staticmethod
-    def render_html_span(token: span_token.HTMLSpan) -> str:
+    def render_html_span(token: span_token.HtmlSpan) -> str:
         return token.content
 
     def render_heading(self, token: block_token.Heading) -> str:
@@ -193,7 +193,7 @@ class HTMLRenderer(BaseRenderer):
         return '\n' if token.soft else '<br />\n'
 
     @staticmethod
-    def render_html_block(token: block_token.HTMLBlock) -> str:
+    def render_html_block(token: block_token.HtmlBlock) -> str:
         return token.content
 
     def render_document(self, token: block_token.Document) -> str:
@@ -224,3 +224,9 @@ class HTMLRenderer(BaseRenderer):
         Escape urls to prevent code injection craziness. (Hopefully.)
         """
         return html.escape(quote(raw, safe='/#:()*?=%@+,&;'))
+
+
+HTMLRenderer = HtmlRenderer
+"""
+Deprecated name of the `HtmlRenderer` class.
+"""

--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -87,7 +87,7 @@ class MarkdownRenderer(BaseRenderer):
     Designed to make as "clean" a roundtrip as possible, markdown -> parsing -> rendering -> markdown,
     except for nonessential whitespace. Except when rendering with word wrapping enabled.
 
-    Includes `HTMLBlock` and `HTMLSpan` tokens in the parsing.
+    Includes `HtmlBlock` and `HtmlSpan` tokens in the parsing.
     """
 
     _whitespace = re.compile(r"\s+")
@@ -102,8 +102,8 @@ class MarkdownRenderer(BaseRenderer):
         super().__init__(
             *chain(
                 (
-                    block_token.HTMLBlock,
-                    span_token.HTMLSpan,
+                    block_token.HtmlBlock,
+                    span_token.HtmlSpan,
                     BlankLine,
                     LinkReferenceDefinitionBlock,
                 ),
@@ -212,7 +212,7 @@ class MarkdownRenderer(BaseRenderer):
             token.content + "\n", wordwrap=token.soft, hard_line_break=not token.soft
         )
 
-    def render_html_span(self, token: span_token.HTMLSpan) -> Iterable[Fragment]:
+    def render_html_span(self, token: span_token.HtmlSpan) -> Iterable[Fragment]:
         yield Fragment(token.content)
 
     def render_link_reference_definition(
@@ -332,7 +332,7 @@ class MarkdownRenderer(BaseRenderer):
         return [token.line]
 
     def render_html_block(
-        self, token: block_token.HTMLBlock, max_line_length: int
+        self, token: block_token.HtmlBlock, max_line_length: int
     ) -> Iterable[str]:
         return token.content.split("\n")
 

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -279,7 +279,7 @@ _declaration = r'(?<!\\)<![A-Z].+?>'
 _cdata       = r'(?<!\\)<!\[CDATA.+?\]\]>'
 
 
-class HTMLSpan(SpanToken):
+class HtmlSpan(SpanToken):
     """
     Span-level HTML token.
     This is an inline token without children.
@@ -292,6 +292,12 @@ class HTMLSpan(SpanToken):
                                    re.DOTALL)
     parse_inner = False
     parse_group = 0
+
+
+HTMLSpan = HtmlSpan
+"""
+Deprecated name of the `HtmlSpan` class.
+"""
 
 
 # Note: The following XWiki tokens are based on the XWiki Syntax 2.0 (or above; 1.0 was deprecated years ago already).

--- a/test/specification/commonmark.py
+++ b/test/specification/commonmark.py
@@ -1,7 +1,7 @@
 import re
 import sys
 import json
-from mistletoe import Document, HTMLRenderer
+from mistletoe import Document, HtmlRenderer
 from traceback import print_tb
 from argparse import ArgumentParser
 
@@ -34,7 +34,7 @@ def run_tests(test_entries, start=None, end=None,
 def run_test(test_entry, quiet=False):
     test_case = test_entry['markdown'].splitlines(keepends=True)
     try:
-        with HTMLRenderer(html_escape_double_quotes=True) as renderer:
+        with HtmlRenderer(html_escape_double_quotes=True) as renderer:
             output = renderer.render(Document(test_case))
         success = test_entry['html'] == output
         if not success and not quiet:

--- a/test/test_ast_renderer.py
+++ b/test/test_ast_renderer.py
@@ -1,7 +1,7 @@
 import unittest
 from mistletoe import Document, ast_renderer 
 
-class TestASTRenderer(unittest.TestCase):
+class TestAstRenderer(unittest.TestCase):
     def test(self):
         self.maxDiff = None
         d = Document(['# heading 1\n', '\n', 'hello\n', 'world\n'])

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -23,7 +23,7 @@ class TestToken(unittest.TestCase):
         self.mock.assert_any_call(arg)
 
 
-class TestATXHeading(TestToken):
+class TestAtxHeading(TestToken):
     def test_match(self):
         lines = ['### heading 3\n']
         arg = 'heading 3'
@@ -135,7 +135,7 @@ class TestBlockCode(TestToken):
 class TestParagraph(TestToken):
     def setUp(self):
         super().setUp()
-        block_token.add_token(block_token.HTMLBlock)
+        block_token.add_token(block_token.HtmlBlock)
         self.addCleanup(block_token.reset_tokens)
 
     def test_parse(self):
@@ -605,9 +605,9 @@ class TestContains(unittest.TestCase):
         self.assertFalse('foo' in token)
 
 
-class TestHTMLBlock(unittest.TestCase):
+class TestHtmlBlock(unittest.TestCase):
     def setUp(self):
-        block_token.add_token(block_token.HTMLBlock)
+        block_token.add_token(block_token.HtmlBlock)
         self.addCleanup(block_token.reset_tokens)
 
     def test_textarea_block_may_contain_blank_lines(self):
@@ -621,12 +621,12 @@ class TestHTMLBlock(unittest.TestCase):
         document = block_token.Document(lines)
         tokens = document.children
         self.assertEqual(1, len(tokens))
-        self.assertIsInstance(tokens[0], block_token.HTMLBlock)
+        self.assertIsInstance(tokens[0], block_token.HtmlBlock)
 
 
 class TestLeafBlockTokenContentProperty(unittest.TestCase):
     def setUp(self):
-        block_token.add_token(block_token.HTMLBlock)
+        block_token.add_token(block_token.HtmlBlock)
         self.addCleanup(block_token.reset_tokens)
 
     def test_code_fence(self):
@@ -666,7 +666,7 @@ class TestLeafBlockTokenContentProperty(unittest.TestCase):
         document = block_token.Document(lines)
         tokens = document.children
         self.assertEqual(1, len(tokens))
-        self.assertIsInstance(tokens[0], block_token.HTMLBlock)
+        self.assertIsInstance(tokens[0], block_token.HtmlBlock)
 
         # option 1: direct access to the content
         self.assertEqual(''.join(lines).strip(), tokens[0].children[0].content)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch, sentinel, mock_open, Mock
 from mistletoe import cli
 
 
-class TestCLI(TestCase):
+class TestCli(TestCase):
     @patch('mistletoe.cli.parse', return_value=Mock(filenames=[], renderer=sentinel.Renderer))
     @patch('mistletoe.cli.interactive')
     def test_main_to_interactive(self, mock_interactive, mock_parse):

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -22,17 +22,17 @@
 
 from test.base_test import BaseRendererTest
 from mistletoe.span_token import tokenize_inner
-from mistletoe.contrib.jira_renderer import JIRARenderer
+from mistletoe.contrib.jira_renderer import JiraRenderer
 import random
 import string
 
 filesBasedTest = BaseRendererTest.filesBasedTest
 
-class TestJIRARenderer(BaseRendererTest):
+class TestJiraRenderer(BaseRendererTest):
 
     def setUp(self):
         super().setUp()
-        self.renderer = JIRARenderer()
+        self.renderer = JiraRenderer()
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)
         self.sampleOutputExtension = 'jira'

--- a/test/test_contrib/test_toc_renderer.py
+++ b/test/test_contrib/test_toc_renderer.py
@@ -1,29 +1,29 @@
 from unittest import TestCase
 from mistletoe import block_token
 from mistletoe.block_token import Document, Heading
-from mistletoe.contrib.toc_renderer import TOCRenderer
+from mistletoe.contrib.toc_renderer import TocRenderer
 
-class TestTOCRenderer(TestCase):
+class TestTocRenderer(TestCase):
     def test_parse_rendered_heading(self):
         rendered_heading = '<h3>some <em>text</em></h3>'
-        content = TOCRenderer.parse_rendered_heading(rendered_heading)
+        content = TocRenderer.parse_rendered_heading(rendered_heading)
         self.assertEqual(content, 'some text')
 
     def test_render_heading(self):
-        renderer = TOCRenderer()
+        renderer = TocRenderer()
         Heading.start('### some *text*\n')
         token = Heading(Heading.read(iter(['foo'])))
         renderer.render_heading(token)
         self.assertEqual(renderer._headings[0], (3, 'some text'))
 
     def test_depth(self):
-        renderer = TOCRenderer(depth=3)
+        renderer = TocRenderer(depth=3)
         token = Document(['# title\n', '## heading\n', '#### heading\n'])
         renderer.render(token)
         self.assertEqual(renderer._headings, [(2, 'heading')])
 
     def test_omit_title(self):
-        renderer = TOCRenderer(omit_title=True)
+        renderer = TocRenderer(omit_title=True)
         token = Document(['# title\n', '\n', '## heading\n'])
         renderer.render(token)
         self.assertEqual(renderer._headings, [(2, 'heading')])
@@ -32,7 +32,7 @@ class TestTOCRenderer(TestCase):
         import re
         filter_conds = [lambda x: re.match(r'heading', x),
                         lambda x: re.match(r'foo', x)]
-        renderer = TOCRenderer(filter_conds=filter_conds)
+        renderer = TocRenderer(filter_conds=filter_conds)
         token = Document(['# title\n',
                           '\n',
                           '## heading\n',
@@ -48,7 +48,7 @@ class TestTOCRenderer(TestCase):
                     (3, 'subsubheading 1'),
                     (2, 'subheading 3'),
                     (1, 'heading 2')]
-        renderer = TOCRenderer(omit_title=False)
+        renderer = TocRenderer(omit_title=False)
         renderer._headings = headings
         toc = renderer.toc
         self.assertIsInstance(toc, block_token.List)

--- a/test/test_html_renderer.py
+++ b/test/test_html_renderer.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
-from mistletoe.html_renderer import HTMLRenderer
+from mistletoe.html_renderer import HtmlRenderer
 from parameterized import parameterized
 
 class TestRenderer(TestCase):
     def setUp(self):
-        self.renderer = HTMLRenderer()
+        self.renderer = HtmlRenderer()
         self.renderer.render_inner = mock.Mock(return_value='inner')
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)
@@ -20,7 +20,7 @@ class TestRenderer(TestCase):
         self.assertEqual(render_func(mock_token), expected_output)
 
 
-class TestHTMLRenderer(TestRenderer):
+class TestHtmlRenderer(TestRenderer):
     def test_strong(self):
         self._test_token('Strong', '<strong>inner</strong>')
 
@@ -57,7 +57,7 @@ class TestHTMLRenderer(TestRenderer):
                          children=False, content='john & jane')
 
     def test_html_span(self):
-        self._test_token('HTMLSpan', '<some>text</some>',
+        self._test_token('HtmlSpan', '<some>text</some>',
                          children=False, content='<some>text</some>')
 
     def test_heading(self):
@@ -92,7 +92,7 @@ class TestHTMLRenderer(TestRenderer):
         self._test_token('ListItem', expected)
 
     def test_table_with_header(self):
-        func_path = 'mistletoe.html_renderer.HTMLRenderer.render_table_row'
+        func_path = 'mistletoe.html_renderer.HtmlRenderer.render_table_row'
         with mock.patch(func_path, autospec=True) as mock_func:
             mock_func.return_value = 'row'
             expected = ('<table>\n'
@@ -102,7 +102,7 @@ class TestHTMLRenderer(TestRenderer):
             self._test_token('Table', expected)
 
     def test_table_without_header(self):
-        func_path = 'mistletoe.html_renderer.HTMLRenderer.render_table_row'
+        func_path = 'mistletoe.html_renderer.HtmlRenderer.render_table_row'
         with mock.patch(func_path, autospec=True) as mock_func:
             mock_func.return_value = 'row'
             expected = '<table>\n<tbody>\ninner</tbody>\n</table>'
@@ -128,7 +128,7 @@ class TestHTMLRenderer(TestRenderer):
 
     def test_html_block(self):
         content = expected = '<h1>hello</h1>\n<p>this is\na paragraph</p>\n'
-        self._test_token('HTMLBlock', expected,
+        self._test_token('HtmlBlock', expected,
                          children=False, content=content)
 
     def test_line_break(self):
@@ -138,7 +138,7 @@ class TestHTMLRenderer(TestRenderer):
         self._test_token('Document', '', footnotes={})
 
 
-class TestHTMLRendererEscaping(TestCase):
+class TestHtmlRendererEscaping(TestCase):
     @parameterized.expand([
         (False, False, '" and \''),
         (False, True, '" and &#x27;'),
@@ -146,14 +146,14 @@ class TestHTMLRendererEscaping(TestCase):
         (True, True, '&quot; and &#x27;'),
     ])
     def test_escape_html_text(self, escape_double, escape_single, expected):
-        with HTMLRenderer(html_escape_double_quotes=escape_double,
+        with HtmlRenderer(html_escape_double_quotes=escape_double,
                           html_escape_single_quotes=escape_single) as renderer:
             self.assertEqual(renderer.escape_html_text('" and \''), expected)
 
 
-class TestHTMLRendererFootnotes(TestCase):
+class TestHtmlRendererFootnotes(TestCase):
     def setUp(self):
-        self.renderer = HTMLRenderer()
+        self.renderer = HtmlRenderer()
         self.renderer.__enter__()
         self.addCleanup(self.renderer.__exit__, None, None, None)
 

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -66,11 +66,11 @@ class TestRepr(unittest.TestCase):
 
     def test_htmlblock(self):
         try:
-            block_token.add_token(block_token.HTMLBlock)
+            block_token.add_token(block_token.HtmlBlock)
             doc = Document("<pre>\nFoo\n</pre>\n")
         finally:
             block_token.reset_tokens()
-        self._check_repr_matches(doc.children[0], "block_token.HTMLBlock with 1 child")
+        self._check_repr_matches(doc.children[0], "block_token.HtmlBlock with 1 child")
         self._check_repr_matches(doc.children[0].children[0], "span_token.RawText content='<pre>\\nFoo\\n</pre>'")
 
     # Span tokens

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -189,17 +189,17 @@ class TestContains(unittest.TestCase):
         self.assertFalse('foo' in token)
 
 
-class TestHTMLSpan(unittest.TestCase):
+class TestHtmlSpan(unittest.TestCase):
     def setUp(self):
-        span_token.add_token(span_token.HTMLSpan)
+        span_token.add_token(span_token.HtmlSpan)
         self.addCleanup(span_token.reset_tokens)
 
     def test_parse(self):
         tokens = span_token.tokenize_inner('<a>')
-        self.assertIsInstance(tokens[0], span_token.HTMLSpan)
+        self.assertIsInstance(tokens[0], span_token.HtmlSpan)
         self.assertEqual('<a>', tokens[0].content)
 
     def test_parse_with_illegal_whitespace(self):
         tokens = span_token.tokenize_inner('< a><\nfoo><bar/ >\n<foo bar=baz\nbim!bop />')
         for t in tokens:
-            self.assertNotIsInstance(t, span_token.HTMLSpan)
+            self.assertNotIsInstance(t, span_token.HtmlSpan)


### PR DESCRIPTION
Fixes #182.

Giving this as a preview of the changes for a while, provided someone would like to give feedback.

Note that backwards compatibility is preserved - by introducing aliases for the old class names.