### PR TITLE
fix inline mathjax handling

### DIFF
--- a/mistletoe/contrib/mathjax.py
+++ b/mistletoe/contrib/mathjax.py
@@ -18,11 +18,11 @@ class MathJaxRenderer(HtmlRenderer, LaTeXRenderer):
 
     def render_math(self, token):
         """
-        Convert single dollar sign enclosed math environments to the \( \) syntax, to support
-        default mathjax settings which ignore single dollar signs for compatibility. 
-        https://docs.mathjax.org/en/latest/basic/mathematics.html#tex-and-latex-input
+        Convert single dollar sign enclosed math expressions to the ``\(...\)`` syntax, to support
+        the default MathJax settings which ignore single dollar signs as described at
+        https://docs.mathjax.org/en/latest/basic/mathematics.html#tex-and-latex-input.
         """
-        if token.content.startswith('$$'): 
+        if token.content.startswith('$$'):
             return self.render_raw_text(token)
         return '\\({}\\)'.format(self.render_raw_text(token).strip('$'))
 

--- a/mistletoe/contrib/mathjax.py
+++ b/mistletoe/contrib/mathjax.py
@@ -18,9 +18,12 @@ class MathJaxRenderer(HtmlRenderer, LaTeXRenderer):
 
     def render_math(self, token):
         """
-        Convert single dollar sign enclosed expressions to \(\) inline math delimiter for mathjax
+        Convert single dollar sign inline math expressions
+        (not supported by mathjax by default) to \( \) inline math delimiter enclosed 
+        expressions(supported by mathjax), let double dollar signs remain, to be 
+        rendered as blockmath by mathjax.
         """
-        if token.content.startswith('$$') or token.content.startswith('\\[') or token.content.startswith('\\('):
+        if token.content.startswith('$$'): 
             return self.render_raw_text(token)
         return '\({}\)'.format(self.render_raw_text(token).strip('$'))
 

--- a/mistletoe/contrib/mathjax.py
+++ b/mistletoe/contrib/mathjax.py
@@ -18,11 +18,11 @@ class MathJaxRenderer(HtmlRenderer, LaTeXRenderer):
 
     def render_math(self, token):
         """
-        Ensure Math tokens are all enclosed in two dollar signs.
+        Convert single dollar sign enclosed expressions to \(\) inline math delimiter for mathjax
         """
-        if token.content.startswith('$$'):
+        if token.content.startswith('$$') or token.content.startswith('\\[') or token.content.startswith('\\('):
             return self.render_raw_text(token)
-        return '${}$'.format(self.render_raw_text(token))
+        return '\({}\)'.format(self.render_raw_text(token).strip('$'))
 
     def render_document(self, token):
         """

--- a/mistletoe/contrib/mathjax.py
+++ b/mistletoe/contrib/mathjax.py
@@ -18,14 +18,13 @@ class MathJaxRenderer(HtmlRenderer, LaTeXRenderer):
 
     def render_math(self, token):
         """
-        Convert single dollar sign inline math expressions
-        (not supported by mathjax by default) to \( \) inline math delimiter enclosed 
-        expressions(supported by mathjax), let double dollar signs remain, to be 
-        rendered as blockmath by mathjax.
+        Convert single dollar sign enclosed math environments to the \( \) syntax, to support
+        default mathjax settings which ignore single dollar signs for compatibility. 
+        https://docs.mathjax.org/en/latest/basic/mathematics.html#tex-and-latex-input
         """
         if token.content.startswith('$$'): 
             return self.render_raw_text(token)
-        return '\({}\)'.format(self.render_raw_text(token).strip('$'))
+        return '\\({}\\)'.format(self.render_raw_text(token).strip('$'))
 
     def render_document(self, token):
         """

--- a/test/test_contrib/test_mathjax.py
+++ b/test/test_contrib/test_mathjax.py
@@ -15,9 +15,9 @@ class TestMathJaxRenderer(unittest.TestCase):
 
     def test_render_math(self):
         with MathJaxRenderer() as renderer:
-            raw = ['# heading 1\n', '$$paragraph$$\n', 'with $ math $\n']
+            raw = ['# heading 1\n', '$$\sum\limits_{i=1}^{\infty} \frac{1}{i^p}$$\n', 'with $  x_3 2^{x}  $\n']
             token = Document(raw)
             output = renderer.render(token)
-            target = '<h1>heading 1</h1>\n<p>$$paragraph$$\nwith $$ math $$</p>\n'
+            target = '<h1>heading 1</h1>\n<p>$$\sum\limits_{i=1}^{\infty} \frac{1}{i^p}$$\nwith \(  x_3 2^{x}  \)</p>\n'
             target += self.mathjax_src
             self.assertEqual(output, target)

--- a/test/test_contrib/test_mathjax.py
+++ b/test/test_contrib/test_mathjax.py
@@ -15,9 +15,9 @@ class TestMathJaxRenderer(unittest.TestCase):
 
     def test_render_math(self):
         with MathJaxRenderer() as renderer:
-            raw = ['# heading 1\n', '$$\sum\limits_{i=1}^{\infty} \frac{1}{i^p}$$\n', 'with $  x_3 2^{x}  $\n']
+            raw = ['math displayed as a block:\n', '$$ \\sum_{i=1}^{\\infty} \\frac{1}{i^p} $$\n', 'math displayed in-line: $ 2^x $\n']
             token = Document(raw)
             output = renderer.render(token)
-            target = '<h1>heading 1</h1>\n<p>$$\sum\limits_{i=1}^{\infty} \frac{1}{i^p}$$\nwith \(  x_3 2^{x}  \)</p>\n'
+            target = '<p>math displayed as a block:\n$$ \\sum_{i=1}^{\\infty} \\frac{1}{i^p} $$\nmath displayed in-line: \\( 2^x \\)</p>\n'
             target += self.mathjax_src
             self.assertEqual(output, target)


### PR DESCRIPTION
previously it was converting mathjax unsupported inline math delimiters $ to block math delimiters $$ which are not equivalent. here it instead converts inline math delim $ to the mathjax supported inline math delim \\( \\) which have the expected equivalent behavior