### PR TITLE
feat: record indentation on list item to make Markdown renderer be able to render list markers followed by 1~4 spaces.

### DIFF
--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -302,7 +302,7 @@ class MarkdownRenderer(BaseRenderer):
     def render_list_item(
         self, token: block_token.ListItem, max_line_length: int
     ) -> Iterable[str]:
-        indentation = len(token.leader) + 1
+        indentation = token.prepend - token.indentation
         max_child_line_length = (
             max_line_length - indentation if max_line_length else None
         )
@@ -310,7 +310,9 @@ class MarkdownRenderer(BaseRenderer):
             token.children, max_line_length=max_child_line_length
         )
         return self.prefix_lines(
-            list(lines) or [""], token.leader + " ", " " * indentation
+            list(lines) or [""],
+            token.leader + " " * (indentation - len(token.leader)),
+            " " * indentation
         )
 
     def render_table(

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -130,11 +130,11 @@ class TestMarkdownRenderer(unittest.TestCase):
 
     def test_numbered_list(self):
         input = [
-            "  22)  *emphasized list item*\n",
-            "  96)\n",
+            "  22) *emphasized list item*\n",
+            "  96) \n",
             " 128) here begins a nested list.\n",
             "       + apples\n",
-            "       +  bananas\n",
+            "       + bananas\n",
         ]
         output = self.roundtrip(input)
         expected = [
@@ -153,6 +153,53 @@ class TestMarkdownRenderer(unittest.TestCase):
             "  [links must be indented][properly].\n",
             "\n",
             "[properly]: uri\n",
+        ]
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
+
+    # we don't currently support keeping margin indentation:
+    def test_list_item_margin_indentation_not_preserved(self):
+        # 0 to 4 spaces of indentation from the margin
+        input = [
+            "- 0 space: ok.\n",
+            "  subsequent line.\n",
+            " - 1 space: ok.\n",
+            "   subsequent line.\n",
+            "  - 2 spaces: ok.\n",
+            "    subsequent line.\n",
+            "   - 3 spaces: ok.\n",
+            "     subsequent line.\n",
+            "    - 4 spaces: in the paragraph of the above list item.\n",
+            "      subsequent line.\n",
+        ]
+        output = self.roundtrip(input)
+        expected = [
+            "- 0 space: ok.\n",
+            "  subsequent line.\n",
+            "- 1 space: ok.\n",
+            "  subsequent line.\n",
+            "- 2 spaces: ok.\n",
+            "  subsequent line.\n",
+            "- 3 spaces: ok.\n",
+            "  subsequent line.\n",
+            "  - 4 spaces: in the paragraph of the above list item.\n",
+            "  subsequent line.\n",
+        ]
+        self.assertEqual(output, "".join(expected))
+
+    def test_list_item_indentation_after_leader_preserved(self):
+        # leaders followed by 1 to 5 spaces
+        input = [
+            "- 1 space: ok.\n",
+            "  subsequent line.\n",
+            "-  2 spaces: ok.\n",
+            "   subsequent line.\n",
+            "-   3 spaces: ok.\n",
+            "    subsequent line.\n",
+            "-    4 spaces: ok.\n",
+            "     subsequent line.\n",
+            "-     5 spaces: list item starting with indented code.\n",
+            "  subsequent line.\n",
         ]
         output = self.roundtrip(input)
         self.assertEqual(output, "".join(input))

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -45,12 +45,12 @@ class TestRepr(unittest.TestCase):
     def test_unordered_list(self):
         doc = Document("* Foo\n* Bar\n* Baz")
         self._check_repr_matches(doc.children[0], "block_token.List with 3 children loose=False start=None")
-        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='*' prepend=2 loose=False")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='*' indentation=0 prepend=2 loose=False")
 
     def test_ordered_list(self):
         doc = Document("1. Foo\n2. Bar\n3. Baz")
         self._check_repr_matches(doc.children[0], "block_token.List with 3 children loose=False start=1")
-        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='1.' prepend=3 loose=False")
+        self._check_repr_matches(doc.children[0].children[0], "block_token.ListItem with 1 child leader='1.' indentation=0 prepend=3 loose=False")
 
     def test_table(self):
         doc = Document("| Foo | Bar | Baz |\n|:--- |:---:| ---:|\n| Foo | Bar | Baz |\n")


### PR DESCRIPTION
With only `ListItem.prepend`, it is not able to keep original indentation of the 1st line in a list item (#196),
so I add the `indentation` to `ListItem` as its member.
The `indentation` is the indentation from the margin.
I also add it to `repr_attributes` because `prepend` is there too.

After recording indentation, Markdown renderer can restore the indentation from the list marker and from the margin.
I weigh the trade-off between thoroughly retaining the format and consistency of formatting feature.
Therefore, Markdown renderer does not restore the indentation from the margin.

input markdown:
```
indentation from the margin
 -   The list item is indented by 1 spaces.

indentation from the list marker
-   The list marker is followed by 3 spaces.
```

implementation details of the 2 examples:
-   Listitem.indentation: 1 and 0
-   Listitem.prepend: 5 and 4

Markdown renderer output:
```
indentation from the margin
-   The list item is indented by 1 spaces.

indentation from the list marker
-   The list marker is followed by 3 spaces.
```