### PR TITLE
Fix penultimate sections of multiline fragments being ignored by the Markdown renderer

### DIFF
--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -409,7 +409,7 @@ class MarkdownRenderer(BaseRenderer):
                 if "\n" in fragment.text:
                     lines = fragment.text.split("\n")
                     yield current_line + lines[0]
-                    for inner_line in lines[1:-2]:
+                    for inner_line in lines[1:-1]:
                         yield inner_line
                     current_line = lines[-1]
                 else:

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -90,6 +90,17 @@ class TestMarkdownRenderer(unittest.TestCase):
         output = self.roundtrip(input)
         self.assertEqual(output, "".join(input))
 
+    def test_multiline_fragment(self):
+        input = [
+            "[a link](<url-in-angle-brackets> '*emphasized\n",
+            "title\n",
+            "spanning\n",
+            "many\n",
+            "lines*')\n",
+        ]
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
+
     def test_thematic_break(self):
         input = [
             " **  * ** * ** * **\n",


### PR DESCRIPTION
When using the Markdown renderer, if a fragment containing newline characters is encountered, it is split by `\n` and each line is yielded in turn.

```py
 for fragment in fragments:
    if "\n" in fragment.text:
        lines = fragment.text.split("\n")
        yield current_line + lines[0]
        for inner_line in lines[1:-2]:
            yield inner_line
        current_line = lines[-1]
    else:
        current_line += fragment.text
```

However, with a quick check in the python REPL we find:

```py
>>> "abcde"[0] 
'a'
>>> "abcde"[1:-2]
'bc'
>>> "abcde"[-1]
'e'
```
Notably, `d`, the penultimate element, is being skipped. 
This can be fixed by changing the bounds of the 'inner' slice from `[1:-2]` to `[1:-1]`.