### PR TITLE
feat(markdown-renderer): option to normalize spacing after the list marker

### DIFF
--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -92,11 +92,22 @@ class MarkdownRenderer(BaseRenderer):
 
     _whitespace = re.compile(r"\s+")
 
-    def __init__(self, *extras, max_line_length: int = None):
+    def __init__(
+        self,
+        *extras,
+        max_line_length: int = None,
+        normalize_whitespace=False
+    ):
         """
-        If `max_line_length` is specified, the document is word wrapped to the
-        specified line length when rendered. Otherwise the formatting from the
-        original (parsed) document is retained as much as possible.
+        Args:
+            extras (list): allows subclasses to add even more custom tokens.
+            max_line_length (int): if specified, the document is word wrapped to the
+                specified line length when rendered. Otherwise the formatting from the
+                original (parsed) document is retained as much as possible.
+            normalize_whitespace (bool): if `False`, the renderer will try to preserve
+                as much whitespace as it currently can. For example, you can
+                use this flag to control whether to replace the original
+                spacing after every list item leader with just 1 space.
         """
         block_token.remove_token(block_token.Footnote)
         super().__init__(
@@ -116,6 +127,7 @@ class MarkdownRenderer(BaseRenderer):
             "LinkReferenceDefinition"
         ] = self.render_link_reference_definition
         self.max_line_length = max_line_length
+        self.normalize_whitespace = normalize_whitespace
 
     def render(self, token: token.Token) -> str:
         """
@@ -302,7 +314,7 @@ class MarkdownRenderer(BaseRenderer):
     def render_list_item(
         self, token: block_token.ListItem, max_line_length: int
     ) -> Iterable[str]:
-        indentation = token.prepend - token.indentation
+        indentation = len(token.leader) + 1 if self.normalize_whitespace else token.prepend - token.indentation
         max_child_line_length = (
             max_line_length - indentation if max_line_length else None
         )

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -7,9 +7,9 @@ from mistletoe.markdown_renderer import MarkdownRenderer
 
 class TestMarkdownRenderer(unittest.TestCase):
     @staticmethod
-    def roundtrip(input):
+    def roundtrip(input, **rendererArgs):
         """Parses the given markdown input and renders it back to markdown again."""
-        with MarkdownRenderer() as renderer:
+        with MarkdownRenderer(**rendererArgs) as renderer:
             return renderer.render(Document(input))
 
     def test_empty_document(self):
@@ -203,6 +203,35 @@ class TestMarkdownRenderer(unittest.TestCase):
         ]
         output = self.roundtrip(input)
         self.assertEqual(output, "".join(input))
+
+    def test_list_item_indentation_after_leader_normalized(self):
+        # leaders followed by 1 to 5 spaces
+        input = [
+            "- 1 space: ok.\n",
+            "  subsequent line.\n",
+            "-  2 spaces: ok.\n",
+            "   subsequent line.\n",
+            "-   3 spaces: ok.\n",
+            "    subsequent line.\n",
+            "-    4 spaces: ok.\n",
+            "     subsequent line.\n",
+            "-     5 spaces: list item starting with indented code.\n",
+            "  subsequent line.\n",
+        ]
+        output = self.roundtrip(input, normalize_whitespace=True)
+        expected = [
+            "- 1 space: ok.\n",
+            "  subsequent line.\n",
+            "- 2 spaces: ok.\n",
+            "  subsequent line.\n",
+            "- 3 spaces: ok.\n",
+            "  subsequent line.\n",
+            "- 4 spaces: ok.\n",
+            "  subsequent line.\n",
+            "-     5 spaces: list item starting with indented code.\n",
+            "  subsequent line.\n",
+        ]
+        self.assertEqual(output, "".join(expected))
 
     def test_code_blocks(self):
         input = [


### PR DESCRIPTION
This follows #197 and adds the possibility to switch ON the original renderer behavior when the space after list marker (called leader in mistletoe) collapsed just to 1 space.