### PR TITLE
build: add proper configuration for tox/tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest parameterized
-        if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+        python -m pip install -r requirements.txt -r test-requirements.txt
+        python -m pip install flake8
     - name: Lint with flake8
       run: |
         # See https://www.flake8rules.com for the list of the rules.
@@ -74,10 +74,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest parameterized
+        python -m pip install -r requirements.txt -r test-requirements.txt
         # note: the following also installs "coverage"
         python -m pip install coveralls
-        if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
     - name: Get coverage report
       run: |
         coverage run --source=${package_name} --append -m pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+# in alphabetical order:
+parameterized
+pytest

--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,11 @@ extend-ignore = E124,E126,E127,E128,E501
 max-line-length = 127
 
 max-complexity = 10
+
+[testenv]
+# Configuration for tox - see https://tox.wiki/en/latest/config.html.
+deps =
+    -r requirements.txt
+    -r test-requirements.txt
+commands =
+    python -m pytest {posargs}


### PR DESCRIPTION
Define all the needed requirements and the
test command, so that running `tox` runs the
unit tests and runs them successfully.

Also simplify the CI workflow by using both
requirements files - exactly how tox does it.

Fixes #220 and #221.