### PR TITLE
include py.typed file to make typing annotations available for library users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author_email='hello@afteryu.me',
     license='MIT',
     packages=['mistletoe', 'mistletoe.contrib'],
+    package_data={'mistletoe': ['py.typed']},
     entry_points={'console_scripts': ['mistletoe = mistletoe.__main__:main']},
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Hi! Mistletoe has type hints, but sadly they aren't available when you're using it as a library unless you include py.typed file (for example see https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package )

I checked the change locally: before the change running mypy on my project would result in this
```
src/promnesia/sources/markdown.py:7:1:7:1: error: Skipping analyzing "mistletoe": module is installed, but missing library stubs or py.typed marker  [import-untyped]
    import mistletoe
    ^
src/promnesia/sources/markdown.py:8:1:8:1: error: Skipping analyzing "mistletoe.span_token": module is installed, but missing library stubs or py.typed marker  [import-untyped]
    from mistletoe.span_token import AutoLink, Link
    ^
```

After the change that works! And now it's catching possible typos etc when using mistletoe