### PR TITLE
fix(latex-renderer): thematic break on new line

### DIFF
--- a/mistletoe/latex_renderer.py
+++ b/mistletoe/latex_renderer.py
@@ -158,7 +158,7 @@ class LaTeXRenderer(BaseRenderer):
 
     @staticmethod
     def render_thematic_break(token):
-        return '\\hrulefill\n'
+        return '\n\\hrulefill\n'
 
     @staticmethod
     def render_line_break(token):

--- a/test/test_latex_renderer.py
+++ b/test/test_latex_renderer.py
@@ -120,7 +120,7 @@ class TestLaTeXRenderer(TestCase):
         self._test_token('TableCell', 'inner')
 
     def test_thematic_break(self):
-        self._test_token('ThematicBreak', '\\hrulefill\n')
+        self._test_token('ThematicBreak', '\n\\hrulefill\n')
 
     def test_line_break(self):
         self._test_token('LineBreak', '\\newline\n', soft=False)


### PR DESCRIPTION
Given the following markdown snippet
```md
line

---

other line
```
and creating a pdf from the rendered LaTeX with pdflatex, version pdfTeX 3.141592653-2.6-1.40.25 (TeX Live 2023/Debian)), I get
![image](https://github.com/user-attachments/assets/6273f556-7d0d-4dd7-9977-cffc6a5621ec)

However, I'd expect the horizontal rule to be on a separate line as shown in the following image
![image](https://github.com/user-attachments/assets/d0907674-d342-4ab2-8fe3-8fa5dd30fbe5)

The attached patch fixes that by adding an empty line before the `\hrulefill`.

To reproduce, run the following script and create a pdf from the resulting LaTeX-file via `pdflatex test.tex`:
```python
#!/bin/env python3

import mistletoe
from mistletoe.latex_renderer import LaTeXRenderer

def render(f):
   with open(f, 'r') as fp:
     return mistletoe.markdown(fp, LaTeXRenderer)

test = """
line

---

other line
"""

open('test.md', 'w').write(test)
open('test.tex', 'w').write(render('test.md'))
```