### PR TITLE
Feat: added setters for content property of block tokens

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -366,6 +366,11 @@ class BlockCode(BlockToken):
         """Returns the code block content."""
         return self.children[0].content
 
+    @content.setter
+    def content(self, value):
+        """Sets the code block content."""
+        self.children[0].content = value
+
     @staticmethod
     def start(line):
         return line.replace('\t', '    ', 1).startswith('    ')
@@ -428,6 +433,11 @@ class CodeFence(BlockToken):
     def content(self):
         """Returns the code block content."""
         return self.children[0].content
+
+    @content.setter
+    def content(self, value):
+        """Sets the code block content."""
+        self.children[0].content = value
 
     @classmethod
     def start(cls, line):
@@ -1039,6 +1049,11 @@ class HtmlBlock(BlockToken):
     def content(self):
         """Returns the raw HTML content."""
         return self.children[0].content
+
+    @content.setter
+    def content(self, value):
+        """Sets the code block content."""
+        self.children[0].content = value
 
     @classmethod
     def start(cls, line):


### PR DESCRIPTION
I'm using `mistletoe` to transform markdown to markdown and added setters to the `content` properties of block token classes in `block_tokens.py`.

I did not add tests yet, since I did not find a suitable place in the existing setup.

