### PR TITLE
docs: fix typos

### DIFF
--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -22,7 +22,7 @@ judgements when employing them.
 </p>
 <h2>Getting started</h2>
 <p>Refer to the <a href="index.html">README</a> for install instructions. Since you&#x27;re going to
-mess with the code, it&#x27;s prefered that you clone the repo directly.
+mess with the code, it&#x27;s preferred that you clone the repo directly.
 </p>
 <p>Check back on the dev branch regularly to avoid redoing work that others might
 have done. The master branch is updated only when features on the dev branch
@@ -94,7 +94,7 @@ things to be aware of:
 <ul>
 <li>mistletoe uses <code>CamelCase</code> for classnames, <code>snake_case</code> for functions and methods;</li>
 <li>mistletoe uses <em>one</em> blank line between classes and functions, even global ones, despite PEP8&#x27;s suggestion to the contrary.</li>
-<li>mistletoe follows the eighty-character rule: if you find your line to be too lengthy, try giving variable names to expressions, and break it up that way. That said, it&#x27;s okay to go over the charater limit occasionally.</li>
+<li>mistletoe follows the eighty-character rule: if you find your line to be too lengthy, try giving variable names to expressions, and break it up that way. That said, it&#x27;s okay to go over the character limit occasionally.</li>
 <li>mistletoe uses four spaces instead of a tab to indent. For vim users, include <code>set ts=4 sw=4 ai et</code> in your <code>.vimrc</code>.</li>
 </ul>
 <p>Apart from that, stay consistent with the coding style around you. But don&#x27;t

--- a/mistletoe/span_tokenizer.py
+++ b/mistletoe/span_tokenizer.py
@@ -64,7 +64,7 @@ def eval_new_child(parent, child):
 
 def relation(x, y):
     if x.end <= y.start:
-        return 0      # x preceeds y
+        return 0      # x precedes y
     if x.end >= y.end:
         if x.parse_start <= y.start and x.parse_end >= y.end:
             return 2  # x contains y

--- a/test/samples/syntax.md
+++ b/test/samples/syntax.md
@@ -298,7 +298,7 @@ Quote Level from the Text menu.
 
 Markdown supports ordered (numbered) and unordered (bulleted) lists.
 
-Unordered lists use asterisks, pluses, and hyphens -- interchangably
+Unordered lists use asterisks, pluses, and hyphens -- interchangeably
 -- as list markers:
 
     *   Red


### PR DESCRIPTION
Found via `codespell -H`