### PR TITLE
Allow numerals in custom token class names

### DIFF
--- a/mistletoe/base_renderer.py
+++ b/mistletoe/base_renderer.py
@@ -41,7 +41,7 @@ class BaseRenderer(object):
         _extras (list): a list of custom tokens to be added to the
                         parsing process.
     """
-    _parse_name = re.compile(r"([A-Z][a-z]+|[A-Z]+(?![a-z]))")
+    _parse_name = re.compile(r"([A-Z][a-z0-9]+|[A-Z]+(?![a-z0-9]))")
 
     def __init__(self, *extras, **kwargs):
         self.render_map = {


### PR DESCRIPTION
Updates the snake regex used to convert custom token class names to render function names, to allow for the use of numerals.

Example use case is in writing custom functions for h1 - h6 elements. In this case, token class names are `CustomH1Token` to `CustomH6Token`.

Expected behavior is that it would attempt to invoke functions `render_custom_h1_token` to `render_custom_h6_token`

However, current behavior instead attempts to invoke the function `render_custom_h_token(self, token)` for all six classes.