### PR TITLE
Allowing BlockToken.start() to receive a second optional argument: lines, a FileReader

### DIFF
--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -22,7 +22,7 @@ class BlankLine(block_token.BlockToken):
         self.children = []
 
     @classmethod
-    def start(cls, line):
+    def start(cls, line, lines):
         return cls.pattern.match(line)
 
     @classmethod


### PR DESCRIPTION
This PR is an alternative to PR #238, that @pbodnar suggested we test in comment https://github.com/miyuchina/mistletoe/pull/238#issuecomment-2708740175

The goal is to implement this feature request: https://github.com/miyuchina/mistletoe/pull/236

Changes introduced by this PR:
* `FileWrapper` now inherits from a new `FileReader` class
* new method `FileWrapper.reader()` that returns a FileReader with read-only access to the same file, positioned at the current index.
* `BlockToken.start()` now receives as a second optional argument a `lines` parameter, that is `FileReader` produced by calling `FileWrapper.reader()`

---

Benchmark results on my computer:

* on the `master` branch:
```
$ python test/benchmark.py mistletoe
Test document: test/samples/syntax.md
Test iterations: 1000
Running tests with mistletoe...
===============================
mistletoe: 19.028154349070974
```

* on this `tokenize_block-always-pass-lines-to-start` branch:
```
$ python test/benchmark.py mistletoe
Test document: test/samples/syntax.md
Test iterations: 1000
Running tests with mistletoe...
===============================
mistletoe: 20.68729400797747
```

To improve performances, we could get rid of the new `FileReader` class,
and simply pass the current `FileWrapper` instance as 2nd argument to `Token.start()`.