### PR TITLE
Fix errors in `remove_token` and `make_fragments`

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -58,7 +58,10 @@ def remove_token(token_cls):
     Arguments:
         token_cls (BlockToken): token to be removed from the parsing process.
     """
-    _token_types.remove(token_cls)
+    try:
+        _token_types.remove(token_cls)
+    except ValueError:
+        pass
 
 
 def reset_tokens():

--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -138,7 +138,7 @@ class MarkdownRenderer(BaseRenderer):
         else:
             lines = self.span_to_lines([token], max_line_length=self.max_line_length)
 
-        return "".join(map(lambda line: line + "\n", lines))
+        return "\n".join(lines) + "\n"
 
     # rendering of span/inline tokens.
     # rendered into sequences of Fragments.
@@ -419,14 +419,16 @@ class MarkdownRenderer(BaseRenderer):
         if not max_line_length:
             # plain rendering: merge all fragments and split on newlines
             for fragment in fragments:
-                if "\n" in fragment.text:
-                    lines = fragment.text.split("\n")
+                if isinstance(fragment, Fragment):
+                    fragment = fragment.text
+                if "\n" in fragment:
+                    lines = fragment.split("\n")
                     yield current_line + lines[0]
                     for inner_line in lines[1:-1]:
                         yield inner_line
                     current_line = lines[-1]
                 else:
-                    current_line += fragment.text
+                    current_line += fragment
         else:
             # render with word wrapping
             for word in cls.make_words(fragments):

--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -400,16 +400,16 @@ class MarkdownRenderer(BaseRenderer):
         """
         Renders a sequence of span (inline) tokens into a sequence of lines.
         """
-        fragments = self.make_fragments(tokens)
+        fragments = self.make_fragments(tokens, max_line_length)
         return self.fragments_to_lines(fragments, max_line_length=max_line_length)
 
-    def make_fragments(self, tokens: Iterable[span_token.SpanToken]
+    def make_fragments(self, tokens: Iterable[span_token.SpanToken], max_line_length: int
     ) -> Iterable[Fragment]:
         """
         Renders a sequence of span (inline) tokens into a sequence of Fragments.
         """
         return chain.from_iterable(
-            [self.render_map[token.__class__.__name__](token) for token in tokens]
+            [self.render_map[token.__class__.__name__](token, max_line_length) for token in tokens]
         )
 
     @classmethod


### PR DESCRIPTION
In `BlockToken.remove_tokens`, an error could be raised when `_token_types` does not contain `token_cls`.

In `MarkdownRenderer.make_fragments`, since all functions in `self.render_map` require the argument `max_line_length`, but currently only a single argument `token` is provided, it also leads to argument errors.