### PR TITLE
Converted stateful global vars to context variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .DS_Store
 *.vim
 .vscode/
+.idea/

--- a/mistletoe/contrib/scheme.py
+++ b/mistletoe/contrib/scheme.py
@@ -74,8 +74,8 @@ class Scheme(BaseRenderer):
             "Number": self.render_number,
             "Variable": self.render_variable,
         }
-        block_token._token_types = []
-        span_token._token_types = [Expr, Number, Variable, Whitespace]
+        block_token._token_types.set([])
+        span_token._token_types.set([Expr, Number, Variable, Whitespace])
 
         self.env = ChainMap({
             "define": self.define,

--- a/mistletoe/core_tokens.py
+++ b/mistletoe/core_tokens.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from contextvars import ContextVar
 from unicodedata import category
 
 
@@ -23,7 +24,8 @@ punctuation = set.union(
 code_pattern = re.compile(r"(?<!\\|`)(?:\\\\)*(`+)(?!`)(.+?)(?<!`)\1(?!`)", re.DOTALL)
 
 
-_code_matches = []
+""" Use together with IsolatedContext to ensure no side effects when parsing markdown documents."""
+_code_matches = ContextVar('code_matches', default=[])
 
 
 def find_core_tokens(string, root):
@@ -41,7 +43,7 @@ def find_core_tokens(string, root):
                 delimiters.append(Delimiter(start, i if not escaped else i - 1, string))
                 in_delimiter_run = None
                 escaped = False
-            _code_matches.append(code_match)
+            _code_matches.get().append(code_match)
             i = code_match.end()
             code_match = code_pattern.search(string, i)
             continue

--- a/mistletoe/isolation.py
+++ b/mistletoe/isolation.py
@@ -1,0 +1,52 @@
+import contextlib
+from mistletoe import block_token
+from mistletoe import span_token
+from mistletoe import core_tokens
+
+
+@contextlib.contextmanager
+def IsolatedContext():
+    """
+    Context manager for isolated document parsing with clean token state.
+
+    Use this context before parsing a document when you need to:
+    - Parse with a clean slate of token types (no previously registered custom tokens)
+    - Ensure parsing doesn't interfere with other parsing operations
+    - Reset all token registrations to default state
+
+    Usage:
+        with IsolatedContext():
+            # Register only the tokens you need for this specific parsing
+            block_token.add_token(MyCustomBlockToken)
+            span_token.add_token(MyCustomSpanToken)
+
+            # Now parse your document with isolated token context
+            doc = mistletoe.Document(markdown_content)
+
+    Can also be used together with a (custom) renderer to ensure isolated token types
+    in asynchronous or multithreaded environments:
+
+    Usage:
+        with IsolatedContext():
+            with MarkdownRenderer() as renderer:
+                # Parse the document with the custom renderer
+                doc = mistletoe.Document(markdown_content)
+                renderer.render(doc)
+
+    The context automatically cleans up token registrations on exit,
+    returning to the default token types state calling the reset functions and
+    ensuring no side effects on subsequent parsing operations.
+    """
+    block_token._token_types.set([])
+    block_token.reset_tokens()
+    span_token._token_types.set([])
+    span_token.reset_tokens()
+    core_tokens._code_matches.set([])
+    try:
+        yield
+    finally:
+        block_token._token_types.set([])
+        block_token.reset_tokens()
+        span_token._token_types.set([])
+        span_token.reset_tokens()
+        core_tokens._code_matches.set([])

--- a/mistletoe/utils.py
+++ b/mistletoe/utils.py
@@ -31,3 +31,4 @@ def traverse(source, klass=None, depth=None, include_source=False):
                 [(child, c) for c in child.children or []]
             )
         next_children = new_children
+

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -8,10 +8,10 @@ from mistletoe import block_token, block_tokenizer, span_token
 
 class TestToken(unittest.TestCase):
     def setUp(self):
-        self.addCleanup(lambda: span_token._token_types.__setitem__(-1, span_token.RawText))
+        self.addCleanup(lambda: span_token._token_types.get().__setitem__(-1, span_token.RawText))
         patcher = patch('mistletoe.span_token.RawText')
         self.mock = patcher.start()
-        span_token._token_types[-1] = self.mock
+        span_token._token_types.get()[-1] = self.mock
         self.addCleanup(patcher.stop)
 
     def _test_match(self, token_cls, lines, arg, **kwargs):

--- a/test/test_contrib/test_github_wiki.py
+++ b/test/test_contrib/test_github_wiki.py
@@ -13,8 +13,8 @@ class TestGithubWiki(TestCase):
 
     def test_parse(self):
         MockRawText = mock.Mock()
-        RawText = span_token._token_types.pop()
-        span_token._token_types.append(MockRawText)
+        RawText = span_token._token_types.get().pop()
+        span_token._token_types.get().append(MockRawText)
         try:
             tokens = tokenize_inner('text with [[wiki | target]]')
             token = tokens[1]
@@ -22,7 +22,7 @@ class TestGithubWiki(TestCase):
             self.assertEqual(token.target, 'target')
             MockRawText.assert_has_calls([mock.call('text with '), mock.call('wiki')])
         finally:
-            span_token._token_types[-1] = RawText
+            span_token._token_types.get()[-1] = RawText
 
     def test_render(self):
         token = next(iter(tokenize_inner('[[wiki|target]]')))

--- a/test/test_isolation.py
+++ b/test/test_isolation.py
@@ -1,0 +1,41 @@
+from mistletoe.isolation import IsolatedContext
+from mistletoe.block_token import _token_types as block_token_types
+from mistletoe.span_token import _token_types as span_token_types
+from mistletoe.core_tokens import _code_matches
+
+def test_isolation_of_contexts():
+
+    assert len(block_token_types.get()) == 9
+    assert len(span_token_types.get()) == 7
+    assert len(_code_matches.get()) == 0
+
+    block_token_types.get().append(1)
+    span_token_types.get().append(1)
+    _code_matches.get().append(1)
+
+    assert len(block_token_types.get()) == 10
+    assert block_token_types.get()[-1] == 1
+    assert len(span_token_types.get()) == 8
+    assert span_token_types.get()[-1] == 1
+    assert len(_code_matches.get()) == 1
+    assert _code_matches.get()[-1] == 1
+
+    with IsolatedContext() as c:
+        assert len(block_token_types.get()) == 9
+        assert len(span_token_types.get()) == 7
+        assert len(_code_matches.get()) == 0
+
+        block_token_types.get().append(2)
+        span_token_types.get().append(2)
+        _code_matches.get().append(2)
+
+        assert len(block_token_types.get()) == 10
+        assert block_token_types.get()[-1] == 2
+        assert len(span_token_types.get()) == 8
+        assert span_token_types.get()[-1] == 2
+        assert len(_code_matches.get()) == 1
+        assert _code_matches.get()[-1] == 2
+
+    assert len(block_token_types.get()) == 9
+    assert len(span_token_types.get()) == 7
+    assert len(_code_matches.get()) == 0

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -5,10 +5,10 @@ from mistletoe import span_token
 
 class TestBranchToken(unittest.TestCase):
     def setUp(self):
-        self.addCleanup(lambda: span_token._token_types.__setitem__(-1, span_token.RawText))
+        self.addCleanup(lambda: span_token._token_types.get().__setitem__(-1, span_token.RawText))
         patcher = patch('mistletoe.span_token.RawText')
         self.mock = patcher.start()
-        span_token._token_types[-1] = self.mock
+        span_token._token_types.get()[-1] = self.mock
         self.addCleanup(patcher.stop)
 
     def _test_parse(self, token_cls, raw, arg, **kwargs):


### PR DESCRIPTION
I converted all stateful global vars to context variables that can be handled within contexts. Added an IsolatedContext context function that can be used to isolate context runs to prevent conflicts on the state of global variables.

I believe that this is a way to solve issues like #210 and #200 without refactoring the whole codebase. Even though a refactor to eliminate the usage of stateful global variables would be desirable.