### PR TITLE
Add types to __init__.py's markdown function

### DIFF
--- a/mistletoe/__init__.py
+++ b/mistletoe/__init__.py
@@ -8,8 +8,8 @@ __all__ = ['html_renderer', 'ast_renderer', 'block_token', 'block_tokenizer',
 
 from typing import Callable, Iterable, Union
 
-from mistletoe.block_token import Document
 from mistletoe.base_renderer import BaseRenderer
+from mistletoe.block_token import Document
 from mistletoe.html_renderer import HtmlRenderer
 # import the old name for backwards compatibility:
 from mistletoe.html_renderer import HTMLRenderer  # noqa: F401


### PR DESCRIPTION
Pyright returns an error when there are no type annotations if using any other `renderer` besides `HtmlRenderer`, because it assumes the type is `type[HtmlRenderer]` instead of `type[BaseRenderer]` like it should be.

To stay compatible with Python 3.5, let's use things from the `typing` module (also used elsewhere in the codebase).