### PR TITLE
fix: avoid crash on overlapping delimiters

### DIFF
--- a/mistletoe/core_tokens.py
+++ b/mistletoe/core_tokens.py
@@ -439,9 +439,10 @@ class Delimiter:
             self.number = self.end - self.start
             self.type = self.type[n:]
             return True
+        # Trim closing markers from the right so type matches start/end.
         self.end = self.end - n
         self.number = self.end - self.start
-        self.type = self.type[:n]
+        self.type = self.type[:-n]
         return True
 
     def closed_by(self, other):

--- a/test/test_core_tokens.py
+++ b/test/test_core_tokens.py
@@ -30,6 +30,7 @@ class TestCoreTokens(TestCase):
         self.assertEqual(delimiter.number, 1)
         self.assertEqual(delimiter.start, 5)
         self.assertEqual(delimiter.end, 6)
+        self.assertEqual(delimiter.type, '*')
 
     def test_delimiter_remove_right(self):
         delimiter = Delimiter(4, 6, 'abcd**')
@@ -37,6 +38,15 @@ class TestCoreTokens(TestCase):
         self.assertEqual(delimiter.number, 1)
         self.assertEqual(delimiter.start, 4)
         self.assertEqual(delimiter.end, 5)
+        self.assertEqual(delimiter.type, '*')
+
+    def test_delimiter_remove_right_from_longer_run(self):
+        delimiter = Delimiter(4, 8, 'abcd****')
+        self.assertTrue(delimiter.remove(1, left=False))
+        self.assertEqual(delimiter.number, 3)
+        self.assertEqual(delimiter.start, 4)
+        self.assertEqual(delimiter.end, 7)
+        self.assertEqual(delimiter.type, '***')
 
     def test_delimiter_remove_empty(self):
         delimiter = Delimiter(4, 6, 'abcd**')

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -35,6 +35,24 @@ class TestStrong(TestBranchToken):
         self._test_token(next(tokens), 'bar', children=True)
         self._test_token(next(tokens), '***baz', children=False)
 
+    def test_overlapping_delimiter_runs_do_not_crash(self):
+        tokens = list(span_token.tokenize_inner('**a****a*'))
+        self.assertEqual(len(tokens), 3)
+        self.assertIsInstance(tokens[0], span_token.Strong)
+        self.assertIsInstance(tokens[2], span_token.Emphasis)
+        self.mock.assert_any_call('*')
+
+    def test_issue_261_asterisk_sequences_do_not_crash(self):
+        cases = [
+            '**IKXZXPTB****AJFHV *Pbjovp*VSN*',
+            '**IKXZXPTB****AJFHV*Pbjovp*',
+            'Ch******her R**a, Bu*****ly In****nt, j**n ko***ob, '
+            'ji*yu, M**s, Ch****us, M*',
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertTrue(list(span_token.tokenize_inner(case)))
+
 
 class TestEmphasis(TestBranchToken):
     def test_parse(self):


### PR DESCRIPTION
The fuzzing discovered crash with IndexError: string index out of range