### PR TITLE
feat: add filtering for URL schemes

### DIFF
--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -3,7 +3,9 @@ HTML renderer for mistletoe.
 """
 
 import html
+import re
 from itertools import chain
+from typing import Iterable, Optional
 from urllib.parse import quote
 from mistletoe import block_token
 from mistletoe import span_token
@@ -11,6 +13,11 @@ from mistletoe.block_token import HtmlBlock
 from mistletoe.span_token import HtmlSpan
 from mistletoe.base_renderer import BaseRenderer
 from mistletoe.base_renderer import URI_SAFE_CHARACTERS
+
+
+DEFAULT_ALLOWED_URL_SCHEMES = frozenset(('http', 'https', 'mailto', 'tel'))
+HARMFUL_LINK_TARGET = '#harmful-link'
+_URL_SCHEME = re.compile(r'^[A-Za-z][A-Za-z0-9+.-]*:')
 
 
 class HtmlRenderer(BaseRenderer):
@@ -25,6 +32,7 @@ class HtmlRenderer(BaseRenderer):
         html_escape_double_quotes=False,
         html_escape_single_quotes=False,
         process_html_tokens=True,
+        allowed_url_schemes: Optional[Iterable[str]] = DEFAULT_ALLOWED_URL_SCHEMES,
         **kwargs
     ):
         """
@@ -37,6 +45,9 @@ class HtmlRenderer(BaseRenderer):
             process_html_tokens (bool): whether to include HTML tokens in the
                 processing. If `False`, HTML markup will be treated as plain
                 text: e.g. input ``<br>`` will be rendered as ``&lt;br&gt;``.
+            allowed_url_schemes (set): URL schemes to allow in links and images.
+                URLs without a scheme are always allowed. Set this to ``None``
+                to allow all schemes.
             **kwargs: additional parameters to be passed to the ancestor's
                 constructor.
         """
@@ -45,6 +56,12 @@ class HtmlRenderer(BaseRenderer):
         super().__init__(*final_extras, **kwargs)
         self.html_escape_double_quotes = html_escape_double_quotes
         self.html_escape_single_quotes = html_escape_single_quotes
+        if allowed_url_schemes is None:
+            self.allowed_url_schemes = None
+        else:
+            self.allowed_url_schemes = frozenset(
+                scheme.lower() for scheme in allowed_url_schemes
+            )
 
     def __exit__(self, *args):
         super().__exit__(*args)
@@ -94,7 +111,7 @@ class HtmlRenderer(BaseRenderer):
     def render_auto_link(self, token: span_token.AutoLink) -> str:
         template = '<a href="{target}">{inner}</a>'
         if token.mailto:
-            target = 'mailto:{}'.format(token.target)
+            target = self.escape_url('mailto:{}'.format(token.target))
         else:
             target = self.escape_url(token.target)
         inner = self.render_inner(token)
@@ -232,12 +249,21 @@ class HtmlRenderer(BaseRenderer):
             s = s.replace('\'', "&#x27;")
         return s
 
-    @staticmethod
-    def escape_url(raw: str) -> str:
+    def escape_url(self, raw: str) -> str:
         """
         Escape urls to prevent code injection craziness. (Hopefully.)
         """
+        if not self.is_url_allowed(raw):
+            return HARMFUL_LINK_TARGET
         return html.escape(quote(raw, safe=URI_SAFE_CHARACTERS))
+
+    def is_url_allowed(self, raw: str) -> bool:
+        if self.allowed_url_schemes is None:
+            return True
+        match = _URL_SCHEME.match(html.unescape(raw).lstrip())
+        if match is None:
+            return True
+        return match.group(0)[:-1].lower() in self.allowed_url_schemes
 
 
 HTMLRenderer = HtmlRenderer

--- a/test/specification/commonmark.py
+++ b/test/specification/commonmark.py
@@ -35,7 +35,10 @@ def run_tests(test_entries, start=None, end=None,
 def run_test(test_entry, quiet=False):
     test_case = test_entry['markdown'].splitlines(keepends=True)
     try:
-        with HtmlRenderer(html_escape_double_quotes=True) as renderer:
+        with HtmlRenderer(
+            html_escape_double_quotes=True,
+            allowed_url_schemes=None,
+        ) as renderer:
             output = renderer.render(Document(test_case))
         success = test_entry['html'] == output
         if not success and not quiet:

--- a/test/test_html_renderer.py
+++ b/test/test_html_renderer.py
@@ -159,6 +159,90 @@ class TestHtmlRendererEscaping(TestCase):
             self.assertEqual(renderer.render(token), expected)
 
 
+class TestHtmlRendererUrlSchemes(TestCase):
+    def render_document(self, lines, **kwargs):
+        with HtmlRenderer(**kwargs) as renderer:
+            return renderer.render(Document(lines))
+
+    @parameterized.expand([
+        ('[x](javascript:alert(1))\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('[x](JAVASCRIPT:alert(1))\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('[x](vbscript:alert(1))\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('[x](data:text/html,<svg>)\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('[x](ftp://example.com)\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('[x](custom:thing)\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('![x](javascript:alert(1))\n', '<p><img src="#harmful-link" alt="x" /></p>\n'),
+        ('<javascript:alert(1)>\n', '<p><a href="#harmful-link">javascript:alert(1)</a></p>\n'),
+    ])
+    def test_disallowed_url_schemes(self, markdown, expected):
+        self.assertEqual(self.render_document([markdown]), expected)
+
+    @parameterized.expand([
+        ('[x](jav&#x61;script:alert(1))\n', '<p><a href="#harmful-link">x</a></p>\n'),
+        ('[x](javascript&#58;alert(1))\n', '<p><a href="#harmful-link">x</a></p>\n'),
+    ])
+    def test_disallowed_url_schemes_with_entities(self, markdown, expected):
+        self.assertEqual(self.render_document([markdown]), expected)
+
+    @parameterized.expand([
+        ('[x](http://example.com)\n', '<p><a href="http://example.com">x</a></p>\n'),
+        ('[x](https://example.com/a?b=1#c)\n',
+         '<p><a href="https://example.com/a?b=1#c">x</a></p>\n'),
+        ('[x](mailto:user@example.com)\n',
+         '<p><a href="mailto:user@example.com">x</a></p>\n'),
+        ('[x](tel:+123456789)\n', '<p><a href="tel:+123456789">x</a></p>\n'),
+        ('[x](/path)\n', '<p><a href="/path">x</a></p>\n'),
+        ('[x](relative/path)\n', '<p><a href="relative/path">x</a></p>\n'),
+        ('[x](?q=1)\n', '<p><a href="?q=1">x</a></p>\n'),
+        ('[x](#section)\n', '<p><a href="#section">x</a></p>\n'),
+        ('<user@example.com>\n',
+         '<p><a href="mailto:user@example.com">user@example.com</a></p>\n'),
+    ])
+    def test_default_allowed_url_schemes(self, markdown, expected):
+        self.assertEqual(self.render_document([markdown]), expected)
+
+    def test_reference_link_url_scheme_is_filtered(self):
+        token = Document(['[x][foo]\n', '\n', '[foo]: javascript:alert(1)\n'])
+        expected = '<p><a href="#harmful-link">x</a></p>\n'
+        with HtmlRenderer() as renderer:
+            self.assertEqual(renderer.render(token), expected)
+
+    def test_reference_image_url_scheme_is_filtered(self):
+        token = Document(['![x][foo]\n', '\n', '[foo]: javascript:alert(1)\n'])
+        expected = '<p><img src="#harmful-link" alt="x" /></p>\n'
+        with HtmlRenderer() as renderer:
+            self.assertEqual(renderer.render(token), expected)
+
+    def test_allowed_url_schemes_can_be_restricted(self):
+        markdown = ['[http](http://example.com) [https](https://example.com)\n']
+        expected = (
+            '<p><a href="#harmful-link">http</a> '
+            '<a href="https://example.com">https</a></p>\n'
+        )
+        self.assertEqual(
+            self.render_document(markdown, allowed_url_schemes={'https'}),
+            expected,
+        )
+
+    def test_allowed_url_schemes_can_be_extended(self):
+        markdown = ['[custom](custom:thing)\n']
+        expected = '<p><a href="custom:thing">custom</a></p>\n'
+        self.assertEqual(
+            self.render_document(
+                markdown,
+                allowed_url_schemes={'https', 'custom'},
+            ),
+            expected,
+        )
+
+    def test_allowed_url_schemes_can_be_disabled(self):
+        markdown = ['[x](javascript:alert(1))\n']
+        expected = '<p><a href="javascript:alert(1)">x</a></p>\n'
+        self.assertEqual(
+            self.render_document(markdown, allowed_url_schemes=None),
+            expected,
+        )
+
 class TestHtmlRendererFootnotes(TestCase):
     def setUp(self):
         self.renderer = HtmlRenderer()


### PR DESCRIPTION
Filter URL schemes in the HTML renderer and allow only http/https/mailto/tel in the default renderer configuration.

Fixes #269

One can also claim that #269 is out of scope and no filtering is needed.