### PR TITLE
fix: escape pipes inside table

### DIFF
--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -512,7 +512,19 @@ class MarkdownRenderer(BaseRenderer):
         """
         Renders each table cell on a table row to text. No word wrapping.
         """
-        return [next(self.span_to_lines(col.children, max_line_length=None), "") for col in row.children]
+        return [
+            self.escape_table_cell_text(
+                next(self.span_to_lines(col.children, max_line_length=None), "")
+            )
+            for col in row.children
+        ]
+
+    @staticmethod
+    def escape_table_cell_text(text: str) -> str:
+        """
+        Escapes text that would otherwise be parsed as a table delimiter.
+        """
+        return text.replace("|", r"\|")
 
     @classmethod
     def calculate_table_column_widths(cls, col_text) -> Sequence[int]:

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -338,6 +338,15 @@ class TestMarkdownRenderer(unittest.TestCase):
         output = self.roundtrip(input)
         self.assertEqual(output, "".join(input))
 
+    def test_table_escapes_pipes_in_cells(self):
+        input = [
+            "| Left column | Right column                  |\n",
+            "| ----------- | ----------------------------- |\n",
+            "| left baz    | right foo \\| between pipes \\| |\n",
+        ]
+        output = self.roundtrip(input)
+        self.assertEqual(output, "".join(input))
+
     def test_table_with_varying_column_counts(self):
         input = [
             "   |   header | x |  \n",


### PR DESCRIPTION
Ensure that pipes in the Markdow rendered tables is escaped.

Fixes #244