### PR TITLE
fix: preserve line break before/after HTML span during word-wrap

### DIFF
--- a/mistletoe/markdown_renderer.py
+++ b/mistletoe/markdown_renderer.py
@@ -408,9 +408,20 @@ class MarkdownRenderer(BaseRenderer):
         """
         Renders a sequence of span (inline) tokens into a sequence of Fragments.
         """
-        return chain.from_iterable(
-            [self.render_map[token.__class__.__name__](token) for token in tokens]
-        )
+        token_list = list(tokens)
+        for i, token in enumerate(token_list):
+            if (
+                isinstance(token, span_token.LineBreak)
+                and token.soft
+                and (
+                    (i + 1 < len(token_list) and isinstance(token_list[i + 1], span_token.HtmlSpan))
+                    or (i > 0 and isinstance(token_list[i - 1], span_token.HtmlSpan))
+                )
+            ):
+                yield Fragment("\n", hard_line_break=True)
+            else:
+                yield from self.render_map[token.__class__.__name__](token)
+
 
     @classmethod
     def fragments_to_lines(

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -638,6 +638,28 @@ class TestMarkdownFormatting(unittest.TestCase):
                 "> > hills of hay\n"
             )
 
+    def test_wordwrap_paragraph_with_html_span_on_own_line(self):
+        with MarkdownRenderer() as renderer:
+            paragraph = block_token.Paragraph(
+                [
+                    "Some long sentence that will be reflowed by the word wrapper.\n",
+                    "</template>\n",
+                    "More text after the tag.\n",
+                ]
+            )
+
+            renderer.max_line_length = 50
+            lines = renderer.render(paragraph)
+
+            # then the closing tag must remain on its own line — not collapsed
+            # onto the end of the previous line, and not merged with the next line
+            assert lines == (
+                "Some long sentence that will be reflowed by the\n"
+                "word wrapper.\n"
+                "</template>\n"
+                "More text after the tag.\n"
+            )
+
     def test_wordwrap_tables(self):
         with MarkdownRenderer(max_line_length=30) as renderer:
             # given a markdown table


### PR DESCRIPTION
When a closing HTML tag (e.g. </template>) appears on its own line in
the source, mistletoe parses the surrounding newlines as soft LineBreaks.
During word-wrap (max_line_length set), soft breaks are treated as
spaces and collapsed, causing the tag to be moved onto the end of the
previous line or the following content to be merged onto the tag's line.


We're seeing this break our html via weblate.
For e.g. in https://codeberg.org/DI-Day/website/pulls/139/files