### PR TITLE
fix(gihub_wiki): reduce backtracking in wiki links

### DIFF
--- a/mistletoe/contrib/github_wiki.py
+++ b/mistletoe/contrib/github_wiki.py
@@ -11,7 +11,8 @@ __all__ = ['GithubWiki', 'GithubWikiRenderer']
 
 
 class GithubWiki(SpanToken):
-    pattern = re.compile(r"\[\[ *(.+?) *\| *(.+?) *\]\]")
+    # In order to avoid inefficient backtracking, we use positive lookahead here.
+    pattern = re.compile(r"\[\[(?=[^\n|]*\|[^\n]*\]\]) *([^\n|]+?) *\| *([^\n]+?) *\]\]")
 
     def __init__(self, match):
         self.target = match.group(2)

--- a/test/test_contrib/test_github_wiki.py
+++ b/test/test_contrib/test_github_wiki.py
@@ -1,4 +1,6 @@
+import time
 from unittest import TestCase, mock
+from parameterized import parameterized
 from mistletoe import span_token, Document, token
 from mistletoe.span_token import tokenize_inner
 from mistletoe.contrib.github_wiki import GithubWiki, GithubWikiRenderer
@@ -28,3 +30,25 @@ class TestGithubWiki(TestCase):
         token = next(iter(tokenize_inner('[[wiki|target]]')))
         output = '<a href="target">wiki</a>'
         self.assertEqual(self.renderer.render(token), output)
+
+    @parameterized.expand([
+        ('[[wiki | target]]', 'wiki', 'target'),
+        ('[[ wiki | target ]]', 'wiki', 'target'),
+        ('[[a | b | c]]', 'a', 'b | c'),
+    ])
+    def test_parse_variant_spacing_and_pipes(self, source, label, target):
+        token = next(iter(tokenize_inner(source)))
+        self.assertIsInstance(token, GithubWiki)
+        self.assertEqual(token.target, target)
+        self.assertEqual(self.renderer.render_inner(token), label)
+
+    @parameterized.expand([
+        ('missing_closing_marker', '[[' + ' ' * 200 + '|' + ' ' * 200 + ']'),
+        ('missing_pipe', '[[' + ' ' * 6000 + ']]'),
+    ])
+    def test_malformed_input_is_rejected_quickly(self, _name, source):
+        start = time.perf_counter()
+        match = GithubWiki.pattern.match(source)
+        elapsed = time.perf_counter() - start
+        self.assertLess(elapsed, 1.0)
+        self.assertIsNone(match)


### PR DESCRIPTION
The lookahead avoids backtracking in invalid patterns while keeping full compatibility.

Fixes #249