### PR TITLE
fix: make remove_token idempotent so renderers can be re-instantiated (#262)

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -56,10 +56,15 @@ def remove_token(token_cls):
     Allows external manipulation of the parsing process.
     This function is usually called in BaseRenderer.__exit__.
 
+    Does nothing if the token class is not currently registered, so that it is
+    safe to call repeatedly (e.g. when a renderer that removes a token is
+    instantiated more than once without being used as a context manager).
+
     Arguments:
         token_cls (BlockToken): token to be removed from the parsing process.
     """
-    _token_types.remove(token_cls)
+    if token_cls in _token_types:
+        _token_types.remove(token_cls)
 
 
 def reset_tokens():

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -47,10 +47,14 @@ def remove_token(token_cls):
     Allows external manipulation of the parsing process.
     This function is called in BaseRenderer.__exit__.
 
+    Does nothing if the token class is not currently registered, so that it is
+    safe to call repeatedly.
+
     Arguments:
         token_cls (SpanToken): token to be removed from the parsing process.
     """
-    _token_types.remove(token_cls)
+    if token_cls in _token_types:
+        _token_types.remove(token_cls)
 
 
 def reset_tokens():

--- a/test/test_markdown_renderer.py
+++ b/test/test_markdown_renderer.py
@@ -12,6 +12,16 @@ class TestMarkdownRenderer(unittest.TestCase):
         with MarkdownRenderer(**rendererArgs) as renderer:
             return renderer.render(Document(input))
 
+    def test_instantiated_twice_without_context_manager(self):
+        # MarkdownRenderer.__init__ removes the Footnote token from the global
+        # block_token._token_types. When the renderer is not used as a context
+        # manager, __exit__ (which calls reset_tokens) never runs, so a second
+        # instantiation must not crash trying to remove an already-absent token.
+        self.addCleanup(block_token.reset_tokens)
+        self.addCleanup(span_token.reset_tokens)
+        MarkdownRenderer()
+        MarkdownRenderer()
+
     def test_empty_document(self):
         input = []
         output = self.roundtrip(input)


### PR DESCRIPTION
Fixes #262.

### Problem

Instantiating `MarkdownRenderer()` a second time without using it as a context manager crashes:

```python
from mistletoe.markdown_renderer import MarkdownRenderer
MarkdownRenderer()
MarkdownRenderer()   # ValueError: list.remove(x): x not in list
```

`MarkdownRenderer.__init__` calls `block_token.remove_token(block_token.Footnote)`, which mutates the module-global `block_token._token_types`. That global is only restored by `reset_tokens()`, which runs in `BaseRenderer.__exit__` — i.e. only when the renderer is used as a `with` context manager. Without `with`, the second instantiation reaches `_token_types.remove(Footnote)` when `Footnote` is already gone and raises. `span_token.remove_token` has the same unguarded pattern.

### Fix

Make `remove_token` idempotent in both `block_token` and `span_token`: only remove the class when it is actually registered. As @pbodnar noted on the issue, a presence check on `_token_types` is what's needed. Context-manager usage is unchanged (verified `reset_tokens` still restores the exact token list on exit).

### Tests

Added a test that instantiates `MarkdownRenderer` twice without a context manager (with cleanup that restores the globals). Without the fix it raises the `ValueError`; with it the full suite passes (342 tests).

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
