### PR TITLE
fix: guard remove_token against duplicate removal (fixes #262)

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -59,7 +59,8 @@ def remove_token(token_cls):
     Arguments:
         token_cls (BlockToken): token to be removed from the parsing process.
     """
-    _token_types.remove(token_cls)
+    if token_cls in _token_types:
+        _token_types.remove(token_cls)
 
 
 def reset_tokens():

--- a/mistletoe/span_token.py
+++ b/mistletoe/span_token.py
@@ -50,7 +50,8 @@ def remove_token(token_cls):
     Arguments:
         token_cls (SpanToken): token to be removed from the parsing process.
     """
-    _token_types.remove(token_cls)
+    if token_cls in _token_types:
+        _token_types.remove(token_cls)
 
 
 def reset_tokens():


### PR DESCRIPTION
`block_token.remove_token()` and `span_token.remove_token()` crash
with `ValueError: list.remove(x): x not in list` when a token is
removed twice without intervening `reset_tokens()`.

Fixes #262.

**Reproduction:**
```python
from mistletoe.markdown_renderer import MarkdownRenderer
r1 = MarkdownRenderer()  # OK
r2 = MarkdownRenderer()  # ValueError
```

**Root cause:** `MarkdownRenderer.__init__` calls
`block_token.remove_token(block_token.Footnote)`. When the renderer
is used without `with`, its `__exit__` never runs, so `reset_tokens()`
never restores Footnote. A second instantiation hits `list.remove(x)`
on a token already absent.

**Fix (+4/-2):** Guard both `remove_token` functions with an
`if token_cls in _token_types` check before calling `.remove()`,
making duplicate removal a safe no-op.

340/340 tests pass.

This pull request was prepared with the assistance of AI, under my
direction and review.
