### PR TITLE
Escape mailto autolink hrefs

### DIFF
--- a/mistletoe/html_renderer.py
+++ b/mistletoe/html_renderer.py
@@ -94,7 +94,7 @@ class HtmlRenderer(BaseRenderer):
     def render_auto_link(self, token: span_token.AutoLink) -> str:
         template = '<a href="{target}">{inner}</a>'
         if token.mailto:
-            target = 'mailto:{}'.format(token.target)
+            target = self.escape_url('mailto:{}'.format(token.target))
         else:
             target = self.escape_url(token.target)
         inner = self.render_inner(token)

--- a/test/test_html_renderer.py
+++ b/test/test_html_renderer.py
@@ -51,6 +51,11 @@ class TestHtmlRenderer(TestRenderer):
         expected = '<a href="link">inner</a>'
         self._test_token('AutoLink', expected, target='link', mailto=False)
 
+    def test_email_autolink_escapes_href(self):
+        expected = '<a href="mailto:a&amp;b@example.com">inner</a>'
+        self._test_token('AutoLink', expected, target='a&b@example.com',
+                         mailto=True)
+
     def test_escape_sequence(self):
         self._test_token('EscapeSequence', 'inner')
 
@@ -157,6 +162,12 @@ class TestHtmlRendererEscaping(TestCase):
             token = Document(['<div><br> as plain text</div>\n'])
             expected = '<p>&lt;div&gt;&lt;br&gt; as plain text&lt;/div&gt;</p>\n'
             self.assertEqual(renderer.render(token), expected)
+
+    def test_email_autolink_escapes_href(self):
+        with HtmlRenderer() as renderer:
+            output = renderer.render(Document('<a&b@example.com>'))
+        expected = '<p><a href="mailto:a&amp;b@example.com">a&amp;b@example.com</a></p>\n'
+        self.assertEqual(output, expected)
 
 
 class TestHtmlRendererFootnotes(TestCase):


### PR DESCRIPTION
## What changed

Email autolink `href` values now go through the same URL and HTML escaping path as normal autolinks.

## Why

`render_auto_link()` escaped regular URL targets, but the `mailto:` branch directly interpolated `mailto:{target}` into an HTML attribute. Email local-parts can contain `&`, so input like `<a&b@example.com>` rendered a bare `&` in `href` even though the link text was escaped:

```html
<a href="mailto:a&b@example.com">a&amp;b@example.com</a>
```

After this change, the attribute renders as:

```html
<a href="mailto:a&amp;b@example.com">a&amp;b@example.com</a>
```

## Validation

- Reproduced the pre-fix output locally with `HtmlRenderer().render(Document('<a&b@example.com>'))`.
- `python -m pytest test\test_html_renderer.py::TestHtmlRenderer::test_email_autolink_escapes_href test\test_html_renderer.py::TestHtmlRendererEscaping::test_email_autolink_escapes_href -q`
- `python -m pytest test\test_html_renderer.py -q`
- `python -m pytest test -q`
- `python -m py_compile mistletoe\html_renderer.py test\test_html_renderer.py`
- `git diff --check`