### PR TITLE
Fix Heading.content leaking the last heading's text (#212)

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -172,11 +172,22 @@ class Heading(BlockToken):
     repr_attributes = BlockToken.repr_attributes + ("level",)
     pattern = re.compile(r' {0,3}(#{1,6})(?:\n|\s+?(.*?)(\n|\s+?#+\s*?$))')
     level = 0
-    content = ''
+    _content = ''
 
     def __init__(self, match):
         self.level, content, self.closing_sequence = match
+        self._content = content
         super().__init__(content, span_token.tokenize_inner)
+
+    @property
+    def content(self):
+        """The raw text of the heading line.
+
+        Stored per-instance rather than as a class attribute mutated by
+        ``start()`` on every parse, which used to make every heading report
+        the last heading's text (see #212).
+        """
+        return self._content
 
     @classmethod
     def start(cls, line):
@@ -184,9 +195,9 @@ class Heading(BlockToken):
         if match_obj is None:
             return False
         cls.level = len(match_obj.group(1))
-        cls.content = (match_obj.group(2) or '').strip()
-        if set(cls.content) == {'#'}:
-            cls.content = ''
+        cls._content = (match_obj.group(2) or '').strip()
+        if set(cls._content) == {'#'}:
+            cls._content = ''
         cls.closing_sequence = (match_obj.group(3) or '').strip()
         return True
 
@@ -197,7 +208,7 @@ class Heading(BlockToken):
     @classmethod
     def read(cls, lines):
         next(lines)
-        return cls.level, cls.content, cls.closing_sequence
+        return cls.level, cls._content, cls.closing_sequence
 
 
 class SetextHeading(BlockToken):

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -48,6 +48,20 @@ class TestAtxHeading(TestToken):
         self.assertIsInstance(token2, block_token.Heading)
         self.assertIsInstance(token3, block_token.Paragraph)
 
+    def test_content_is_per_instance(self):
+        # Regression for #212: each heading must report its own raw text
+        # rather than the last-parsed heading's (which used to leak through a
+        # shared class attribute).
+        lines = ['# first\n', '\n', '## second\n', '\n', '### third\n']
+        headings = [
+            token
+            for token in block_token.tokenize(lines)
+            if isinstance(token, block_token.Heading)
+        ]
+        self.assertEqual(
+            [heading.content for heading in headings], ['first', 'second', 'third']
+        )
+
 
 class TestSetextHeading(TestToken):
     def test_match(self):


### PR DESCRIPTION
## Summary

Fixes #212. Every `Heading`'s `.content` returned the **last** parsed heading's text:

```python
from mistletoe import Document
from mistletoe.block_token import Heading

doc = Document(["## A\n", "\n", "## B\n", "\n", "## C\n"])
[t.content for t in doc.children if isinstance(t, Heading)]
# before: ['C', 'C', 'C']
# after:  ['A', 'B', 'C']
```

## Root cause

`Heading` keeps its raw text on the **class**: `start()` assigns `cls.content`, and `__init__` never sets it on the instance. So `heading.content` resolved to the class attribute, which `start()` overwrites on every parse — leaving every heading reporting the last heading's text.

## Fix

Store the raw text per-instance and expose it through a read-only `content` property.

Importantly, the value is kept out of `vars(token)` under the key `content` (it lives in `_content`, surfaced via the property). mistletoe's AST renderer and `__repr__` serialize `content` only when `"content" in vars(token)` — so this change **does not** alter the AST/`repr` output, and `Heading` is not newly serialized with a `content` field. (This keeps the existing behaviour discussed in #212 where `content` is a meaningful *serialized* attribute only for tokens like `BlockCode`/`HtmlBlock`.)

The change is backwards compatible: `heading.content` still works, and now returns the correct per-heading text. If you'd instead prefer to drop `content` from `Heading` entirely, I'm happy to adjust — but this keeps existing callers working while removing the incorrect shared-state value.

## Verification

- Added `TestAtxHeading.test_content_is_per_instance`; it fails on `master` (all headings report `'third'`) and passes here.
- Full test suite passes: 349 tests OK (was 348).
- `flake8` (CI's `--select=E9,F63,F7,F82,W605`) clean on the changed files; AST/repr tests unchanged.

---

*Disclosure: prepared with AI assistance; reviewed and verified locally against the test suite.*
