### PR TITLE
fix: avoid IndexError on empty blockquote/list item in JIRA and XWiki renderers

### DIFF
--- a/mistletoe/contrib/jira_renderer.py
+++ b/mistletoe/contrib/jira_renderer.py
@@ -106,9 +106,13 @@ class JiraRenderer(BaseRenderer):
         return template.format(level=token.level, inner=inner) + self._block_eol(token)
 
     def render_quote(self, token):
-        self.lastChildOfQuotes.append(token.children[-1])
+        # an empty blockquote (">") has no last child to track
+        tracked = bool(token.children)
+        if tracked:
+            self.lastChildOfQuotes.append(token.children[-1])
         inner = self.render_inner(token)
-        del (self.lastChildOfQuotes[-1])
+        if tracked:
+            del (self.lastChildOfQuotes[-1])
 
         if len(token.children) == 1 and isinstance(token.children[0], block_token.Paragraph):
             template = 'bq. {inner}' + self._block_eol(token)[0:-1]

--- a/mistletoe/contrib/xwiki20_renderer.py
+++ b/mistletoe/contrib/xwiki20_renderer.py
@@ -94,9 +94,13 @@ class XWiki20Renderer(BaseRenderer):
         return template.format(level='=' * token.level, inner=inner) + self._block_eol(token)
 
     def render_quote(self, token):
-        self.lastChildOfQuotes.append(token.children[-1])
+        # an empty blockquote (">") has no last child to track
+        tracked = bool(token.children)
+        if tracked:
+            self.lastChildOfQuotes.append(token.children[-1])
         inner = self.render_inner(token)
-        del (self.lastChildOfQuotes[-1])
+        if tracked:
+            del (self.lastChildOfQuotes[-1])
 
         return (
             "".join(
@@ -133,9 +137,13 @@ class XWiki20Renderer(BaseRenderer):
         if '1' in self.listTokens:
             prefix += '.'
 
-        self.firstChildOfListItems.append(token.children[0])
+        # an empty list item ("- ") has no first child to track
+        tracked = bool(token.children)
+        if tracked:
+            self.firstChildOfListItems.append(token.children[0])
         inner = self.render_inner(token)
-        del (self.firstChildOfListItems[-1])
+        if tracked:
+            del (self.firstChildOfListItems[-1])
 
         result = template.format(prefix=prefix, inner=inner.rstrip())
 

--- a/test/test_contrib/test_jira_renderer.py
+++ b/test/test_contrib/test_jira_renderer.py
@@ -232,6 +232,10 @@ public static void main(String[] args) {
 """
         self.markdownResultTest(markdown, expected)
 
+    def test_render_empty_quote(self):
+        # an empty blockquote (">") has no last child; must not raise IndexError
+        self.markdownResultTest('>\n', '{quote}\n{quote}\n\n')
+
     @filesBasedTest
     def test_render__basic_blocks(self):
         pass

--- a/test/test_contrib/test_xwiki20_renderer.py
+++ b/test/test_contrib/test_xwiki20_renderer.py
@@ -114,6 +114,14 @@ Use this feature with //caution//. See {{Wikipedia article="SomeArticle"/}}. {{t
 """
         self.markdownResultTest(markdown, expected)
 
+    def test_render_empty_quote(self):
+        # an empty blockquote (">") has no last child; must not raise IndexError
+        self.markdownResultTest('>\n', '\n')
+
+    def test_render_empty_list_item(self):
+        # an empty list item ("- ") has no first child; must not raise IndexError
+        self.markdownResultTest('- \n', '* \n\n')
+
     @filesBasedTest
     def test_render__basic_blocks(self):
         pass


### PR DESCRIPTION
`markdown('>', JIRARenderer)` and `markdown('>', XWiki20Renderer)` raise `IndexError: list index out of range`. XWiki additionally raises on an empty list item, e.g. `markdown('- ', XWiki20Renderer)`.

Both renderers track a quote's last child (and, in XWiki, a list item's first child) to decide block spacing, doing `token.children[-1]` / `token.children[0]` unconditionally in `render_quote` / `render_list_item`. An empty blockquote (`>`) or empty list item (`- `) has no children, so the index raises. These are valid CommonMark constructs that the core HTML, AST, LaTeX, and Markdown renderers all handle fine.

The fix skips the tracking (and its matching `del`) when the container is empty. `_block_eol`, which consumes the tracking stacks, already guards for an empty stack, so nothing else needs to change. Empty containers now render as their empty form, and non-empty quotes and lists are unchanged.

Repro:

```python
from mistletoe import markdown
from mistletoe.contrib.jira_renderer import JIRARenderer
from mistletoe.contrib.xwiki20_renderer import XWiki20Renderer
markdown('>', JIRARenderer)       # IndexError
markdown('- ', XWiki20Renderer)   # IndexError
```

Added `test_render_empty_quote` (both renderers) and `test_render_empty_list_item` (XWiki).
