### PR TITLE
Don't treat a whitespace-only line as the start of an indented code block

### DIFF
--- a/mistletoe/block_token.py
+++ b/mistletoe/block_token.py
@@ -382,7 +382,7 @@ class BlockCode(BlockToken):
 
     @staticmethod
     def start(line):
-        return line.replace('\t', '    ', 1).startswith('    ')
+        return line.strip() != '' and line.replace('\t', '    ', 1).startswith('    ')
 
     @classmethod
     def read(cls, lines):

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -133,6 +133,24 @@ class TestBlockCode(TestToken):
         arg = 'chunk1\n\nchunk2\n\n\n\nchunk3\n'
         self._test_match(block_token.BlockCode, lines, arg, language='')
 
+    @parameterized.expand([
+        ('tab_only', '\t\n'),
+        ('four_spaces', '    \n'),
+        ('over_four_spaces', '     \n'),
+        ('spaces_then_tab', '  \t\n'),
+    ])
+    def test_blank_line_does_not_start_code(self, _, line):
+        # A line containing only spaces or tabs is a blank line and must not
+        # begin an indented code block (CommonMark 0.30, "Blank lines").
+        self.assertFalse(block_token.BlockCode.start(line))
+
+    def test_blank_line_not_parsed_as_code(self):
+        lines = ['foo\n', '\t\n', 'bar\n']
+        tokens = block_token.tokenize(lines)
+        self.assertEqual(len(tokens), 2)
+        self.assertIsInstance(tokens[0], block_token.Paragraph)
+        self.assertIsInstance(tokens[1], block_token.Paragraph)
+
 
 class TestParagraph(TestToken):
     def setUp(self):


### PR DESCRIPTION
A line containing only whitespace starts a spurious indented code block:

```python
import mistletoe
mistletoe.markdown("foo\n\t\nbar\n")
# <p>foo</p>\n<pre><code>\t\n</code></pre>\n<p>bar</p>\n   — a code block appears between the paragraphs
mistletoe.markdown("\t\n")     # <pre><code>\t\n</code></pre>\n
mistletoe.markdown("    \n")   # <pre><code>\n</code></pre>\n  (4 spaces)
```

Per CommonMark, "a line containing only spaces or tabs is called a blank line", and blank lines never begin an indented code block — so all three should render as no code block (`"foo\n\t\nbar\n"` → two paragraphs). Both reference implementations agree: `commonmark` 0.9.2 and `markdown-it-py` 4.2.0 (CommonMark mode) produce the empty / two-paragraph output.

**Root cause** (`mistletoe/block_token.py`, `BlockCode.start`): it returned `line.replace('\t', '    ', 1).startswith('    ')`, which is true for a whitespace-only line whose leading tab/spaces expand to a 4-space prefix.

**Fix** (1 line): require the line to be non-blank before it can *start* a code block.

```python
-        return line.replace('\t', '    ', 1).startswith('    ')
+        return line.strip() != '' and line.replace('\t', '    ', 1).startswith('    ')
```

Interior blank lines within a code block are handled by `BlockCode.read`, not `start`, so real indented code — including blank lines inside it — is unaffected (verified: `"    real code\n"` still renders as a code block; the existing `test_parse_indented_code_with_blank_lines` still passes).

**Verification** (re-runnable from the diff):
- Before: the three inputs above emit a `<pre><code>`. After: they render correctly (empty / two paragraphs), matching both reference implementations.
- Added `test_blank_line_does_not_start_code` (tab-only / 4-spaces / >4-spaces / spaces+tab) and `test_blank_line_not_parsed_as_code` (the `foo\n\t\nbar` integration case) to `TestBlockCode`; they fail on the current tree and pass with the fix.
- `test/` → 352 passed, 1 skipped (pre-existing); the shipped CommonMark 0.30 spec suite (`python -m test.specification`) still reports **all tests passing**.

Realistic trigger: editors routinely leave a trailing tab/spaces on an otherwise-blank line.

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
