### PR TITLE
Add test_remove_span_from_processing for coverage of span_token

### DIFF
--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -737,3 +737,8 @@ class TestRemoveToken(unittest.TestCase):
         block_token.remove_token(block_token.BlockCode)
         self.assertNotIn(block_token.BlockCode, block_token._token_types)
 
+        # Check second removal does not raise error (pull request #281 issue #262)
+        try:
+            block_token.remove_token(block_token.BlockCode)
+        except ValueError:
+            self.fail("Idempotent removal failed")

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -725,6 +725,7 @@ class TestFileWrapper(unittest.TestCase):
         wrapper.reset()
         assert next(wrapper) == "somewhat interesting\n"
 
+
 class TestRemoveToken(unittest.TestCase):
     def setUp(self):
         self.addCleanup(block_token.reset_tokens)

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -724,3 +724,15 @@ class TestFileWrapper(unittest.TestCase):
         assert next(wrapper) == "somewhat interesting\n"
         wrapper.reset()
         assert next(wrapper) == "somewhat interesting\n"
+
+class TestRemoveToken(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(block_token.reset_tokens)
+
+    def test_remove_token_from_processing(self):
+        # Check that token exists
+        self.assertIn(block_token.BlockCode, block_token._token_types)
+        
+        block_token.remove_token(block_token.BlockCode)
+        self.assertNotIn(block_token.BlockCode, block_token._token_types)
+

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -234,12 +234,13 @@ class TestHtmlSpan(unittest.TestCase):
 
 class TestRemoveToken(unittest.TestCase):
     def setUp(self):
+        span_token._token_types.clear() # .clear() to remove duplicates
+        span_token.add_token(span_token.RawText)
         self.addCleanup(span_token.reset_tokens)
 
-    def test_remove_span_from_processing(self):
-        self.assertEqual(len(span_token._token_types), len(span_token.__all__))
+    def test_remove_token_from_processing(self):
+        # Check that token exists
+        self.assertIn(span_token.RawText, span_token._token_types)
+        
         span_token.remove_token(span_token.RawText)
-        self.assertEqual(len(span_token._token_types), len(span_token.__all__) - 1)
-        # Check that trying to remove twice still works
-        span_token.remove_token(span_token.RawText)
-        self.assertEqual(len(span_token._token_types), len(span_token.__all__) - 1)
+        self.assertNotIn(span_token.RawText, span_token._token_types)

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -230,3 +230,16 @@ class TestHtmlSpan(unittest.TestCase):
         tokens = span_token.tokenize_inner('< a><\nfoo><bar/ >\n<foo bar=baz\nbim!bop />')
         for t in tokens:
             self.assertNotIsInstance(t, span_token.HtmlSpan)
+
+
+class TestRemoveToken(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(span_token.reset_tokens)
+
+    def test_remove_span_from_processing(self):
+        self.assertEqual(len(span_token._token_types), len(span_token.__all__))
+        span_token.remove_token(span_token.RawText)
+        self.assertEqual(len(span_token._token_types), len(span_token.__all__) - 1)
+        # Check that trying to remove twice still works
+        span_token.remove_token(span_token.RawText)
+        self.assertEqual(len(span_token._token_types), len(span_token.__all__) - 1)

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -242,3 +242,9 @@ class TestRemoveToken(unittest.TestCase):
         
         span_token.remove_token(span_token.RawText)
         self.assertNotIn(span_token.RawText, span_token._token_types)
+
+        # Check second removal does not raise error (pull request #281 issue #262)
+        try:
+            span_token.remove_token(span_token.RawText)
+        except ValueError:
+            self.fail("Idempotent removal failed")

--- a/test/test_span_token.py
+++ b/test/test_span_token.py
@@ -234,8 +234,6 @@ class TestHtmlSpan(unittest.TestCase):
 
 class TestRemoveToken(unittest.TestCase):
     def setUp(self):
-        span_token._token_types.clear() # .clear() to remove duplicates
-        span_token.add_token(span_token.RawText)
         self.addCleanup(span_token.reset_tokens)
 
     def test_remove_token_from_processing(self):


### PR DESCRIPTION
I was looking at test coverages and saw we were not stepping in a branch that ran `remove_tokens()`. I wrote a small test case for that in `test_span_token.py`. 